### PR TITLE
[KUDU-53] support duplication to kafka

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1246,6 +1246,23 @@ ADD_THIRDPARTY_LIB(boost_date_time
     STATIC_LIB "${BOOST_DATE_TIME_STATIC_LIB}"
     SHARED_LIB "${BOOST_DATE_TIME_SHARED_LIB}")
 
+## librdkafka
+find_package(RdKafka REQUIRED)
+include_directories(SYSTEM ${RDKAFKA_INCLUDE_DIR})
+ADD_THIRDPARTY_LIB(rdkafka
+    STATIC_LIB "${RDKAFKA_STATIC_LIB}"
+    SHARED_LIB "${RDKAFKA_SHARED_LIB}")
+
+## cppkafka
+find_package(CppKafka REQUIRED)
+include_directories(SYSTEM ${CPPKAFKA_INCLUDE_DIR})
+ADD_THIRDPARTY_LIB(cppkafka
+    STATIC_LIB "${CPPKAFKA_STATIC_LIB}"
+    SHARED_LIB "${CPPKAFKA_SHARED_LIB}")
+
+# prepare for kafka env for duplication test.
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/kafka-simple-control.sh DESTINATION /tmp)
+
 ############################################################
 # Enable sized deallocation where supported.
 # This happens down here instead of up with the rest of the
@@ -1482,6 +1499,8 @@ add_subdirectory(src/kudu/clock)
 add_subdirectory(src/kudu/codegen)
 add_subdirectory(src/kudu/common)
 add_subdirectory(src/kudu/consensus)
+# for duplication hot backup or others functions
+add_subdirectory(src/kudu/duplicator)
 add_subdirectory(src/kudu/experiments)
 add_subdirectory(src/kudu/fs)
 # Google util libraries borrowed from supersonic, tcmalloc, Chromium, etc.

--- a/cmake_modules/FindCppKafka.cmake
+++ b/cmake_modules/FindCppKafka.cmake
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+find_path(CPPKAFKA_INCLUDE_DIR cppkafka/cppkafka.h
+    # make sure we don't accidentally pick up a different Version
+    NO_CMAKE_SYSTEM_PATH
+    NO_SYSTEM_ENVIRONMENT_PATH)
+find_library(CPPKAFKA_STATIC_LIB libcppkafka.a
+    NO_CMAKE_SYSTEM_PATH
+    NO_SYSTEM_ENVIRONMENT_PATH)
+
+set(__CURRENT_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+if (APPLE)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES, ".dylib")
+else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES, ".so")
+endif()
+
+find_library(CPPKAFKA_SHARED_LIB cppkafka
+    NO_CMAKE_SYSTEM_PATH
+    NO_SYSTEM_ENVIRONMENT_PATH)
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${__CURRENT_FIND_LIBRARY_SUFFIXES})
+unset(__CURRENT_FIND_LIBRARY_SUFFIXES)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CPPKAFKA REQUIRED_VARS
+    CPPKAFKA_STATIC_LIB CPPKAFKA_SHARED_LIB CPPKAFKA_INCLUDE_DIR)

--- a/cmake_modules/FindRdKafka.cmake
+++ b/cmake_modules/FindRdKafka.cmake
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+find_path(RDKAFKA_INCLUDE_DIR librdkafka/rdkafka.h
+    # make sure we don't accidentally pick up a different Version
+    NO_CMAKE_SYSTEM_PATH
+    NO_SYSTEM_ENVIRONMENT_PATH)
+find_library(RDKAFKA_STATIC_LIB librdkafka.a
+    NO_CMAKE_SYSTEM_PATH
+    NO_SYSTEM_ENVIRONMENT_PATH)
+
+set(__CURRENT_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+if (APPLE)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES, ".dylib")
+else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES, ".so")
+endif()
+
+find_library(RDKAFKA_SHARED_LIB rdkafka
+    NO_CMAKE_SYSTEM_PATH
+    NO_SYSTEM_ENVIRONMENT_PATH)
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${__CURRENT_FIND_LIBRARY_SUFFIXES})
+unset(__CURRENT_FIND_LIBRARY_SUFFIXES)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(RDKAFKA REQUIRED_VARS
+    RDKAFKA_STATIC_LIB RDKAFKA_SHARED_LIB RDKAFKA_INCLUDE_DIR)

--- a/java/kudu-client/src/main/java/org/apache/kudu/client/AlterTableOptions.java
+++ b/java/kudu-client/src/main/java/org/apache/kudu/client/AlterTableOptions.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
+import org.apache.kudu.master.Master;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 
@@ -454,6 +455,73 @@ public class AlterTableOptions {
    */
   public AlterTableOptions alterExtraConfigs(Map<String, String> extraConfig) {
     pb.putAllNewExtraConfigs(extraConfig);
+    return this;
+  }
+
+  /**
+   * Enable the table's duplication, default Kafka
+   *
+   * @param name Kafka Topic Name
+   */
+  public AlterTableOptions enableDuplication(String name) {
+    Master.AlterTableRequestPB.Step.Builder stepBuilder = Master.AlterTableRequestPB.Step.newBuilder();
+    Master.DuplicationInfo.Builder builder = Master.DuplicationInfo.newBuilder()
+        .setName(name).setType(Master.DuplicationDownstream.KAFKA);
+    stepBuilder.setType(AlterTableRequestPB.StepType.ADD_DUPLICATION)
+        .setAddDuplication(Master.AlterTableRequestPB.AddDuplication
+        .newBuilder().setDupInfo(builder.build()).build());
+    pb.addAlterSchemaSteps(stepBuilder.build());
+    return this;
+  }
+
+  public AlterTableOptions disableDuplication(String name) {
+    Master.AlterTableRequestPB.Step.Builder stepBuilder = Master.AlterTableRequestPB.Step.newBuilder();
+    stepBuilder.setType(AlterTableRequestPB.StepType.DROP_DUPLICATION)
+        .setDropDuplication(Master.AlterTableRequestPB.DropDuplication
+            .newBuilder().setName(name).build());
+    pb.addAlterSchemaSteps(stepBuilder.build());
+    return this;
+  }
+
+  /**
+   * Enable the table's duplication
+   * @TODO support more than one duplication
+   *
+   * @param name
+   * @param streamType duplication's destination system, such as Kafka
+   * @return
+   */
+  public AlterTableOptions addDuplications(String name, Master.DuplicationDownstream streamType) {
+    return addDuplications(name, streamType, null, null);
+  }
+  public AlterTableOptions addDuplications(String name, Master.DuplicationDownstream streamType, String uri) {
+    return addDuplications(name, streamType, uri, null);
+  }
+  /**
+   * Enable the table's duplication
+   * @TODO support more than one duplication
+   *
+   * @param name
+   * @param streamType duplication's destination system, such as Kafka
+   * @param uri optional
+   * @param options such as user token infomation, json format
+   * @return
+   */
+  public AlterTableOptions addDuplications(String name, Master.DuplicationDownstream streamType,
+      String uri, String options) {
+    Master.AlterTableRequestPB.Step.Builder stepBuilder = Master.AlterTableRequestPB.Step.newBuilder();
+    Master.DuplicationInfo.Builder builder = Master.DuplicationInfo.newBuilder();
+    builder.setName(name).setType(streamType);
+    if (uri != null && "".equals(uri)) {
+      builder.setUri(uri);
+    }
+    if (options != null && "".equals(options)) {
+      builder.setOptions(options);
+    }
+    stepBuilder.setType(AlterTableRequestPB.StepType.ADD_DUPLICATION)
+        .setAddDuplication(Master.AlterTableRequestPB.AddDuplication
+        .newBuilder().setDupInfo(builder.build()).build());
+    pb.addAlterSchemaSteps(stepBuilder.build());
     return this;
   }
 

--- a/java/kudu-client/src/main/java/org/apache/kudu/client/CreateTableOptions.java
+++ b/java/kudu-client/src/main/java/org/apache/kudu/client/CreateTableOptions.java
@@ -270,6 +270,67 @@ public class CreateTableOptions {
     return this;
   }
 
+  /**
+   *  Enable the table's duplication, default kafka
+   *
+   * @param name Kafka Topic Name
+  */
+  public CreateTableOptions enableDuplication(String name) {
+    Master.DuplicationInfo.Builder builder = Master.DuplicationInfo.newBuilder();
+    builder.setName(name)
+        .setType(Master.DuplicationDownstream.KAFKA);
+    pb.addDupInfos(builder.build());
+    return this;
+  }
+
+  /**
+   * Enable the table's duplication
+   * @TODO support more than one duplication
+   *
+   * @param name
+   * @param streamType duplication's destination system, such as Kafka
+   * @return CreateTableOptions
+   */
+  public CreateTableOptions addDuplications(String name, Master.DuplicationDownstream streamType) {
+    return addDuplications(name, streamType, null, null);
+  }
+  /**
+   * Enable the table's duplication
+   * @TODO support more than one duplication
+   *
+   * @param name
+   * @param streamType duplication's destination system, such as Kafka
+   * @param uri optional, destination's discovered service name
+   * @return CreateTableOptions
+   */
+  public CreateTableOptions addDuplications(String name, Master.DuplicationDownstream streamType, String uri) {
+    return addDuplications(name, streamType, uri, null);
+  }
+  /**
+   * Enable the table's duplication
+   * @TODO support more than one duplication
+   *
+   * @param name
+   * @param streamType duplication's destination system, such as Kafka
+   * @param uri optional, destination's discovered service name
+   * @param options such as user token infomation, json format
+   * @return CreateTableOptions
+   */
+  public CreateTableOptions addDuplications(String name, Master.DuplicationDownstream streamType,
+      String uri, String options) {
+    Master.DuplicationInfo.Builder builder = Master.DuplicationInfo.newBuilder();
+    builder.setName(name)
+        .setType(streamType);
+    if (uri != null && "".equals(uri)) {
+      builder.setUri(uri);
+    }
+    if (options != null && "".equals(options)) {
+      builder.setOptions(options);
+    }
+    pb.addDupInfos(builder.build());
+    return this;
+  }
+
   Master.CreateTableRequestPB.Builder getBuilder() {
     if (!splitRows.isEmpty() || !rangePartitions.isEmpty()) {
       pb.setSplitRowsRangeBounds(new Operation.OperationsEncoder()

--- a/src/kudu/client/client.h
+++ b/src/kudu/client/client.h
@@ -70,6 +70,10 @@ class KuduClient;
 class KuduTable;
 } // namespace client
 
+namespace master {
+class DuplicationInfo;
+} // namespace master
+
 namespace tablet {
 class FuzzTest;
 } // namespace tablet
@@ -1082,6 +1086,9 @@ class KUDU_EXPORT KuduReplica {
   /// any time.
   bool is_leader() const;
 
+  /// @return Whether or not this replica is a duplicator.
+  bool is_duplicator() const;
+
   /// @return The tablet server hosting this remote replica.
   const KuduTabletServer& ts() const;
 
@@ -1129,6 +1136,20 @@ class KUDU_EXPORT KuduTablet {
 
   DISALLOW_COPY_AND_ASSIGN(KuduTablet);
 };
+
+enum class DuplicationDownstream {
+  UNKNOWN = 0,
+  KAFKA
+};
+
+struct DuplicationInfo {
+  std::string name;
+  DuplicationDownstream type;
+  std::string uri;
+  std::string options;
+};
+
+extern bool ToDuplicationInfoPB(const DuplicationInfo& info, master::DuplicationInfo* dup_info);
 
 /// @brief A helper class to create a new table with the desired options.
 class KUDU_EXPORT KuduTableCreator {
@@ -1398,6 +1419,17 @@ class KUDU_EXPORT KuduTableCreator {
   ///   The table's extra configuration properties.
   /// @return Reference to the modified table creator.
   KuduTableCreator& extra_configs(const std::map<std::string, std::string>& extra_configs);
+
+
+  /// With one or more duplicators for tablet of table
+  ///
+  /// If the value of the kv pair is empty, the property will be ignored.
+  ///
+  /// @param [in] extra_configs
+  ///   The table's extra configuration properties.
+  /// @return Reference to the modified table creator.
+  KuduTableCreator& duplication(const DuplicationInfo& dup_info);
+
 
   /// Set the timeout for the table creation operation.
   ///
@@ -1962,6 +1994,11 @@ class KUDU_EXPORT KuduTableAlterer {
       KuduTableCreator::RangePartitionBound lower_bound_type = KuduTableCreator::INCLUSIVE_BOUND,
       KuduTableCreator::RangePartitionBound upper_bound_type = KuduTableCreator::EXCLUSIVE_BOUND);
 
+
+  KuduTableAlterer* AddDuplicationInfo(const DuplicationInfo& info);
+
+  KuduTableAlterer* DropDuplicationInfo(const DuplicationInfo& info);
+  
   /// Change the table's extra configuration properties.
   ///
   /// @note These configuration properties will be merged into existing configuration properties.

--- a/src/kudu/client/replica_controller-internal.cc
+++ b/src/kudu/client/replica_controller-internal.cc
@@ -35,6 +35,10 @@ bool ReplicaController::is_voter(const KuduReplica& replica) {
   return replica.data_->is_voter_;
 }
 
+bool ReplicaController::is_duplicator(const KuduReplica& replica) {
+  return !replica.data_->is_voter_;
+}
+
 } // namespace internal
 } // namespace client
 } // namespace kudu

--- a/src/kudu/client/replica_controller-internal.h
+++ b/src/kudu/client/replica_controller-internal.h
@@ -46,6 +46,8 @@ class ReplicaController {
 
   static bool is_voter(const KuduReplica& replica);
 
+  static bool is_duplicator(const KuduReplica& replica);
+
  private:
   ReplicaController();
 

--- a/src/kudu/client/table_alterer-internal.cc
+++ b/src/kudu/client/table_alterer-internal.cc
@@ -200,6 +200,19 @@ Status KuduTableAlterer::Data::ToRequest(AlterTableRequestPB* req) {
         encoder.Add(upper_bound_type, *s.upper_bound);
         break;
       }
+      case AlterTableRequestPB::ADD_DUPLICATION:
+      {
+        master::DuplicationInfo* info = pb_step->mutable_add_duplication()->mutable_dup_info();
+        info->set_name(s.dup_info->name);
+        // TODO(duyuqi), convert it to real downstream type
+        info->set_type(master::KAFKA);
+        break;
+      }
+      case AlterTableRequestPB::DROP_DUPLICATION:
+      {
+        pb_step->mutable_drop_duplication()->set_name(s.dup_info->name);
+        break;
+      }
       default:
         LOG(FATAL) << "unknown step type " << AlterTableRequestPB::StepType_Name(s.step_type);
     }

--- a/src/kudu/client/table_alterer-internal.h
+++ b/src/kudu/client/table_alterer-internal.h
@@ -67,6 +67,9 @@ class KuduTableAlterer::Data {
 
     // The dimension label for tablet. Only set when the StepType is ADD_RANGE_PARTITION.
     boost::optional<std::string> dimension_label;
+
+    // Duplication Info
+    boost::optional<client::DuplicationInfo> dup_info;
   };
   std::vector<Step> steps_;
 

--- a/src/kudu/client/table_creator-internal.cc
+++ b/src/kudu/client/table_creator-internal.cc
@@ -29,6 +29,7 @@ namespace client {
 KuduTableCreator::Data::Data(KuduClient* client)
     : client_(client),
       schema_(nullptr),
+      dup_info_(boost::none),
       wait_(true) {
 }
 

--- a/src/kudu/client/table_creator-internal.h
+++ b/src/kudu/client/table_creator-internal.h
@@ -81,6 +81,8 @@ class KuduTableCreator::Data {
 
   boost::optional<std::map<std::string, std::string>> extra_configs_;
 
+  boost::optional<client::DuplicationInfo> dup_info_;
+
   boost::optional<TableTypePB> table_type_;
 
   MonoDelta timeout_;

--- a/src/kudu/common/types-test.cc
+++ b/src/kudu/common/types-test.cc
@@ -134,6 +134,14 @@ namespace {
                                        lower, upper, get<2>(test_case)));
 
       ASSERT_EQ(get<2>(test_case), info->AreConsecutive(&get<0>(test_case), &get<1>(test_case)));
+
+      string slower, supper;
+      info->StringForValue(&get<0>(test_case), &slower);
+      info->StringForValue(&get<1>(test_case), &supper);
+
+      SCOPED_TRACE(strings::Substitute("lower: $0, upper: $1, expected: $2",
+                                       slower, supper, get<2>(test_case)));
+      ASSERT_EQ(get<2>(test_case), info->AreConsecutive(&get<0>(test_case), &get<1>(test_case)));
     }
   }
 } // anonymous namespace

--- a/src/kudu/common/types.cc
+++ b/src/kudu/common/types.cc
@@ -45,6 +45,7 @@ TypeInfo::TypeInfo(TypeTraitsClass /*t*/)
     max_value_(TypeTraitsClass::max_value()),
     is_virtual_(TypeTraitsClass::IsVirtual()),
     append_func_(TypeTraitsClass::AppendDebugStringForValue),
+    stringify_func_(TypeTraitsClass::StringForValue),
     compare_func_(TypeTraitsClass::Compare),
     are_consecutive_func_(TypeTraitsClass::AreConsecutive) {
 }
@@ -55,6 +56,10 @@ void TypeInfo::AppendDebugStringForValue(const void *ptr, string *str) const {
   } else {
     append_func_(ptr, str);
   }
+}
+
+void TypeInfo::StringForValue(const void *ptr, string *str) const {
+  stringify_func_(ptr, str);
 }
 
 int TypeInfo::Compare(const void *lhs, const void *rhs) const {

--- a/src/kudu/common/types.h
+++ b/src/kudu/common/types.h
@@ -64,6 +64,7 @@ class TypeInfo {
   const std::string& name() const { return name_; }
   const size_t size() const { return size_; }
   void AppendDebugStringForValue(const void *ptr, std::string *str) const;
+  void StringForValue(const void *ptr, std::string *str) const;
   int Compare(const void *lhs, const void *rhs) const;
   // Returns true if increment(a) is equal to b.
   bool AreConsecutive(const void* a, const void* b) const;
@@ -93,6 +94,7 @@ class TypeInfo {
 
   typedef void (*AppendDebugFunc)(const void *, std::string *);
   const AppendDebugFunc append_func_;
+  const AppendDebugFunc stringify_func_;
 
   typedef int (*CompareFunc)(const void *, const void *);
   const CompareFunc compare_func_;
@@ -144,6 +146,9 @@ struct DataTypeTraits<UINT8> {
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     str->append(SimpleItoa(*reinterpret_cast<const uint8_t *>(val)));
   }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
+  }
   static int Compare(const void *lhs, const void *rhs) {
     return GenericCompare<UINT8>(lhs, rhs);
   }
@@ -170,6 +175,9 @@ struct DataTypeTraits<INT8> {
   }
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     str->append(SimpleItoa(*reinterpret_cast<const int8_t *>(val)));
+  }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
   }
   static int Compare(const void *lhs, const void *rhs) {
     return GenericCompare<INT8>(lhs, rhs);
@@ -198,6 +206,9 @@ struct DataTypeTraits<UINT16> {
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     str->append(SimpleItoa(*reinterpret_cast<const uint16_t *>(val)));
   }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
+  }
   static int Compare(const void *lhs, const void *rhs) {
     return GenericCompare<UINT16>(lhs, rhs);
   }
@@ -224,6 +235,9 @@ struct DataTypeTraits<INT16> {
   }
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     str->append(SimpleItoa(*reinterpret_cast<const int16_t *>(val)));
+  }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
   }
   static int Compare(const void *lhs, const void *rhs) {
     return GenericCompare<INT16>(lhs, rhs);
@@ -252,6 +266,9 @@ struct DataTypeTraits<UINT32> {
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     str->append(SimpleItoa(*reinterpret_cast<const uint32_t *>(val)));
   }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
+  }
   static int Compare(const void *lhs, const void *rhs) {
     return GenericCompare<UINT32>(lhs, rhs);
   }
@@ -278,6 +295,9 @@ struct DataTypeTraits<INT32> {
   }
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     str->append(SimpleItoa(*reinterpret_cast<const int32_t *>(val)));
+  }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
   }
   static int Compare(const void *lhs, const void *rhs) {
     return GenericCompare<INT32>(lhs, rhs);
@@ -306,6 +326,9 @@ struct DataTypeTraits<UINT64> {
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     str->append(SimpleItoa(*reinterpret_cast<const uint64_t *>(val)));
   }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
+  }
   static int Compare(const void *lhs, const void *rhs) {
     return GenericCompare<UINT64>(lhs, rhs);
   }
@@ -332,6 +355,9 @@ struct DataTypeTraits<INT64> {
   }
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     str->append(SimpleItoa(*reinterpret_cast<const int64_t *>(val)));
+  }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
   }
   static int Compare(const void *lhs, const void *rhs) {
     return GenericCompare<INT64>(lhs, rhs);
@@ -360,6 +386,9 @@ struct DataTypeTraits<INT128> {
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     str->append(SimpleItoa(UnalignedLoad<int128_t>(val)));
   }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
+  }
   static int Compare(const void *lhs, const void *rhs) {
     return GenericCompare<INT128>(lhs, rhs);
   }
@@ -387,6 +416,9 @@ struct DataTypeTraits<FLOAT> {
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     str->append(SimpleFtoa(*reinterpret_cast<const float *>(val)));
   }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
+  }
   static int Compare(const void *lhs, const void *rhs) {
     return GenericCompare<FLOAT>(lhs, rhs);
   }
@@ -413,6 +445,9 @@ struct DataTypeTraits<DOUBLE> {
   }
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     str->append(SimpleDtoa(*reinterpret_cast<const double *>(val)));
+  }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
   }
   static int Compare(const void *lhs, const void *rhs) {
     return GenericCompare<DOUBLE>(lhs, rhs);
@@ -443,6 +478,10 @@ struct DataTypeTraits<BINARY> {
     str->push_back('"');
     str->append(strings::CHexEscape(s->ToString()));
     str->push_back('"');
+  }
+  static void StringForValue(const void *val, std::string *str) {
+    const Slice *s = reinterpret_cast<const Slice *>(val);
+    str->append(s->ToString());
   }
   static int Compare(const void *lhs, const void *rhs) {
     const Slice *lhs_slice = reinterpret_cast<const Slice *>(lhs);
@@ -484,6 +523,9 @@ struct DataTypeTraits<BOOL> {
   static void AppendDebugStringForValue(const void* val, std::string* str) {
     str->append(*reinterpret_cast<const bool *>(val) ? "true" : "false");
   }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
+  }
   static int Compare(const void *lhs, const void *rhs) {
     return GenericCompare<BOOL>(lhs, rhs);
   }
@@ -512,6 +554,9 @@ struct DerivedTypeTraits {
 
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     DataTypeTraits<PhysicalType>::AppendDebugStringForValue(val, str);
+  }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
   }
 
   static int Compare(const void *lhs, const void *rhs) {
@@ -545,6 +590,10 @@ struct DataTypeTraits<STRING> : public DerivedTypeTraits<BINARY>{
     str->append(strings::Utf8SafeCEscape(s->ToString()));
     str->push_back('"');
   }
+  static void StringForValue(const void *val, std::string *str) {
+    const Slice *s = reinterpret_cast<const Slice *>(val);
+    str->append(s->ToString());
+  }
 };
 
 
@@ -576,6 +625,9 @@ struct DataTypeTraits<UNIXTIME_MICROS> : public DerivedTypeTraits<INT64>{
     snprintf(time, sizeof(time), kDateMicrosAndTzFormat, time_up_to_secs, remaining_micros);
     str->append(time);
   }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
+  }
 };
 
 template<>
@@ -589,6 +641,9 @@ struct DataTypeTraits<DATE> : public DerivedTypeTraits<INT32>{
   }
 
   static void AppendDebugStringForValue(const void* val, std::string* str);
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
+  }
 
   static const cpp_type* min_value() {
     static int32_t value = kMinValue;
@@ -615,6 +670,9 @@ struct DataTypeTraits<DECIMAL32> : public DerivedTypeTraits<INT32>{
     DataTypeTraits<physical_type>::AppendDebugStringForValue(val, str);
     str->append("_D32");
   }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
+  }
 };
 
 template<>
@@ -629,6 +687,9 @@ struct DataTypeTraits<DECIMAL64> : public DerivedTypeTraits<INT64>{
     DataTypeTraits<physical_type>::AppendDebugStringForValue(val, str);
     str->append("_D64");
   }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
+  }
 };
 
 template<>
@@ -642,6 +703,9 @@ struct DataTypeTraits<DECIMAL128> : public DerivedTypeTraits<INT128>{
   static void AppendDebugStringForValue(const void *val, std::string *str) {
     DataTypeTraits<physical_type>::AppendDebugStringForValue(val, str);
     str->append("_D128");
+  }
+  static void StringForValue(const void *val, std::string *str) {
+    AppendDebugStringForValue(val, str);
   }
 };
 
@@ -665,6 +729,10 @@ struct DataTypeTraits<VARCHAR> : public DerivedTypeTraits<BINARY>{
     str->push_back('"');
     str->append(strings::Utf8SafeCEscape(s->ToString()));
     str->push_back('"');
+  }
+  static void StringForValue(const void *val, std::string *str) {
+    const Slice *s = reinterpret_cast<const Slice*>(val);
+    str->append(s->ToString());
   }
 };
 

--- a/src/kudu/consensus/consensus.proto
+++ b/src/kudu/consensus/consensus.proto
@@ -103,6 +103,7 @@ enum DriverType {
   UNKNOWN_DRIVER = 0;
   LEADER = 1;
   FOLLOWER = 2;
+  DUPLICA = 3;
 }
 
 // A configuration change request for the tablet with 'tablet_id'.

--- a/src/kudu/consensus/consensus_meta.cc
+++ b/src/kudu/consensus/consensus_meta.cc
@@ -169,6 +169,12 @@ bool ConsensusMetadata::IsMemberInConfig(const string& uuid,
   return IsRaftConfigMember(uuid, GetConfig(type));
 }
 
+bool ConsensusMetadata::IsDuplicatorInConfig(const string& uuid, 
+                                             RaftConfigState type) {
+  DFAKE_SCOPED_RECURSIVE_LOCK(fake_lock_);
+  return IsRaftConfigDuplicator(uuid, GetConfig(type));
+}
+
 int ConsensusMetadata::CountVotersInConfig(RaftConfigState type) {
   DFAKE_SCOPED_RECURSIVE_LOCK(fake_lock_);
   return CountVoters(GetConfig(type));

--- a/src/kudu/consensus/consensus_meta.h
+++ b/src/kudu/consensus/consensus_meta.h
@@ -96,6 +96,10 @@ class ConsensusMetadata : public RefCountedThreadSafe<ConsensusMetadata> {
   // local Raft config.
   bool IsMemberInConfig(const std::string& uuid, RaftConfigState type);
 
+  // Return true iff peer with specified uuid is a duplicator in the specified
+  // local Raft config.
+  bool IsDuplicatorInConfig(const std::string& uuid, RaftConfigState type);
+
   // Returns a count of the number of voters in the specified local Raft
   // config.
   int CountVotersInConfig(RaftConfigState type);

--- a/src/kudu/consensus/metadata.proto
+++ b/src/kudu/consensus/metadata.proto
@@ -94,6 +94,9 @@ message RaftPeerPB {
     UNKNOWN_MEMBER_TYPE = 999;
     NON_VOTER = 0;
     VOTER = 1;
+    // DUPLICATOR is a special NON_VOTER which cann't promote to VOTER,
+    // the raft role is LEARNER
+    DUPLICATOR = 2;
   };
 
   // Permanent uuid is optional: RaftPeerPB/RaftConfigPB instances may

--- a/src/kudu/consensus/quorum_util.h
+++ b/src/kudu/consensus/quorum_util.h
@@ -33,6 +33,7 @@ enum RaftConfigState {
 
 bool IsRaftConfigMember(const std::string& uuid, const RaftConfigPB& config);
 bool IsRaftConfigVoter(const std::string& uuid, const RaftConfigPB& config);
+bool IsRaftConfigDuplicator(const std::string& uuid, const RaftConfigPB& config);
 
 // Whether the specified Raft role is attributed to a peer which can participate
 // in leader elections.
@@ -61,6 +62,7 @@ bool ReplicaTypesEqual(const RaftPeerPB& peer1, const RaftPeerPB& peer2);
 
 // Counts the number of voters in the configuration.
 int CountVoters(const RaftConfigPB& config);
+int CountMembers(const RaftConfigPB& config, RaftPeerPB::MemberType type);
 
 // Calculates size of a configuration majority based on # of voters.
 int MajoritySize(int num_voters);
@@ -113,6 +115,10 @@ bool ShouldAddReplica(const RaftConfigPB& config,
                       int replication_factor,
                       const std::unordered_set<std::string>& uuids_ignored_for_underreplication =
                           std::unordered_set<std::string>());
+bool ShouldAddDuplicator(const RaftConfigPB& config,
+                         int duplication_factor,
+                         const std::unordered_set<std::string>& uuid_ignored_for_underreplication =
+                         std::unordered_set<std::string>());
 
 // Check if the given Raft configuration contains at least one extra replica
 // which should (and can) be removed in accordance with the specified

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -87,6 +87,9 @@ struct ServerContext {
   // Threadpool on which to run Raft tasks.
   ThreadPool* raft_pool;
 
+  // ThreadPool on which to run duplication tasks
+  ThreadPool* duplicate_pool;
+
   // Shared boolean indicating whether Raft consensus should continue sending request messages
   // even if a peer is considered as failed.
   const bool* allow_status_msg_for_failed_peer = nullptr;
@@ -170,6 +173,11 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
 
   // Returns true if RaftConsensus is running.
   bool IsRunning() const;
+
+  // Returns true if local replica is duplicator, used by init.
+  bool IsDuplicator() {
+    return cmeta_->IsDuplicatorInConfig(local_peer_pb_.permanent_uuid(), ACTIVE_CONFIG);
+  }
 
   // Emulates an election by increasing the term number and asserting leadership
   // in the configuration by sending a NO_OP to other peers.

--- a/src/kudu/duplicator/CMakeLists.txt
+++ b/src/kudu/duplicator/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+PROTOBUF_GENERATE_CPP(
+  KAFKA_PROTO_SRCS KAFKA_PROTO_HDRS KAFKA_PROTO_TGTS
+  SOURCE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..
+  BINARY_ROOT ${CMAKE_CURRENT_BINARY_DIR}/../..
+  PROTO_FILES kafka/kafka.proto)
+
+ADD_EXPORTABLE_LIBRARY(kafka_proto
+  SRCS ${KAFKA_PROTO_SRCS}
+  DEPS protobuf
+  NONLINK_DEPS ${KAFKA_PROTO_TGTS})
+
+add_library(kafka duplicator.cc kafka/kafka_connector.cc)
+
+target_link_libraries(kafka cppkafka rdkafka kafka_proto log_proto)
+
+SET_KUDU_TEST_LINK_LIBS(tablet kafka kudu_test_util kudu_common)
+ADD_KUDU_TEST(kafka/kafka_connector-test)
+
+

--- a/src/kudu/duplicator/connector.h
+++ b/src/kudu/duplicator/connector.h
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// The file is define a Common Connector interface api, 
+// if user need to duplicate data to another storage, 
+// user should extend the interface just as kafka/kafka_connector.h.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <string>
+
+#include "kudu/common/schema.h"
+#include "kudu/tablet/ops/write_op.h"
+#include "kudu/tablet/row_op.h"
+#include "kudu/util/status.h"
+#include "google/protobuf/arena.h"
+#include "kudu/util/memory/arena.h"
+
+namespace kudu {
+namespace duplicator {
+
+using std::string;
+
+struct DuplicateMsg {
+  const std::shared_ptr<tablet::WriteOpState> op_state;
+  const tablet::RowOp* row_op;
+  std::shared_ptr<Schema> schema_ptr;
+  std::string table_name;
+
+  DuplicateMsg(const std::shared_ptr<tablet::WriteOpState>& _op_state,
+               const tablet::RowOp* _row_op,
+               const std::shared_ptr<Schema>& _schema_ptr,
+               const std::string& _table_name)
+      : op_state(_op_state), row_op(_row_op),
+        schema_ptr(_schema_ptr), table_name(_table_name) {
+
+      }
+
+  DuplicateMsg(const DuplicateMsg& /**/) = delete;
+  void operator=(const DuplicateMsg& /**/) = delete;
+};
+
+class Connector {
+ public:
+  virtual ~Connector() = default;
+  virtual Status InitPrepare() = 0;
+  virtual Status Init() = 0;
+  virtual Status WriteBatch(const std::vector<std::shared_ptr<DuplicateMsg>>& msgs) = 0;
+  // For test basic client api
+  virtual Status TestBasicClientApi(const std::string& /* msg */) { return Status::OK(); }
+};
+
+/**
+ * Local Connector, such as mongodb's hidden replica.
+ * Also for some situation's backup.
+ * If use KuduConnector, that's just added another replica,
+ * but non-voter.
+ * If use kv Connector, eg: leveldb/rocksdb, it can serving some random query
+ * more effient
+ */
+class LocalConnector : public Connector {
+ public:
+  LocalConnector() : Connector() {}
+  virtual ~LocalConnector() = default;
+};
+
+class RemoteConnector : public Connector {
+ public:
+  RemoteConnector() : Connector() {}
+  virtual ~RemoteConnector() = default;
+};
+
+/**
+ * KuduLocalConnector's special, it can be implemented directly.
+ * It equals Kudu has 4 replicas and 1 is learner not participant in voting.
+ * So the class will not use.
+ * The class just is a represent for LocalConnector.
+ */
+class KuduLocalConnector : public LocalConnector {
+ public:
+  KuduLocalConnector() : LocalConnector() {}
+  virtual ~KuduLocalConnector() = default;
+  virtual Status Init() override {
+    LOG(INFO) << "KuduLocalConnector Init()";
+    return Status::OK();
+  }
+  virtual Status WriteBatch(const std::vector<std::shared_ptr<DuplicateMsg>>& /* msgs */) override {
+    LOG(INFO) << "KuduLocalConnector WriteBatch(), just stand for it. not use";
+    return Status::OK();
+  }
+};
+
+}  // namespace duplicator
+}  // namespace kudu
+
+/* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/src/kudu/duplicator/duplicator.cc
+++ b/src/kudu/duplicator/duplicator.cc
@@ -1,0 +1,146 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// The file is define a Duplicator interface api, 
+// if user need to duplicate data to another storage, 
+// user should implement the interface just like kafka below.
+
+#include "kudu/duplicator/duplicator.h"
+
+#include <deque>
+#include <functional>
+#include <ostream>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include "kudu/consensus/opid_util.h"
+#include "kudu/duplicator/kafka/kafka_connector.h"
+#include "kudu/tablet/tablet.h"
+#include "kudu/tablet/tablet_metadata.h"
+#include "kudu/util/monotime.h"
+#include "kudu/util/threadpool.h"
+
+namespace kudu {
+class Schema;
+namespace tablet {
+struct RowOp;
+}  // namespace tablet
+}  // namespace kudu
+
+DEFINE_string(downstream_type, "kafka", "");
+DEFINE_int64(duplicate_pool_timeout_s, 10, "");
+
+static bool ValidateDownstreamFlag(const char* flagname, const std::string& value) {
+  if (value == "kafka" || value == "local_kudu") {
+    return true;
+  }
+  LOG(ERROR) << "duplication downstream_type should be: kafka, local_kudu";
+  return false;
+}
+DEFINE_validator(downstream_type, &ValidateDownstreamFlag);
+
+namespace kudu {
+namespace duplicator {
+
+Duplicator::Duplicator(ThreadPool* thread_pool, const std::string& table_name)
+    : duplicate_pool_(thread_pool),
+      table_name_(table_name),
+      last_confirmed_opid_(consensus::MinimumOpId()),
+      stopped_(true),
+      queue_(8192) {
+  // #ifdef ENABLE_DUPLICATION
+
+  if (FLAGS_downstream_type == "kafka") {
+    connector_ = kafka::KafkaConnector<cppkafka::Producer>::GetInstance();
+  } else {
+    // Not Supported
+    connector_ = nullptr;
+  }
+  // #else
+  // Not Support
+  //    connector_ = nullptr;
+  //#endif
+}
+Duplicator::~Duplicator() {
+  // @TODO(duyuqi)
+  // no release connector, for its a shared object
+  connector_ = nullptr;
+}
+
+Status Duplicator::Init() {
+  stopped_ = false;
+  connector_->Init();
+  duplicate_pool_token_ = duplicate_pool_->NewToken(ThreadPool::ExecutionMode::SERIAL
+                                                    // TODO metric_entity for duplicate_pool_
+  );
+  return Status::OK();
+}
+
+Status Duplicator::Shutdown() {
+  stopped_ = true;
+  // TODO(duyuqi), duplicate_pool_token_ should not shutdown for its shared
+  // if (duplicate_pool_token_ != nullptr) {
+  //   duplicate_pool_token_->Shutdown();
+  // }
+  // TODO deal queue data
+  return Status::OK();
+}
+
+void Duplicator::Duplicate(const std::shared_ptr<tablet::WriteOpState>& write_op_state_ptr, 
+                           const tablet::RowOp* row_op, const std::shared_ptr<Schema>& schema) {
+  if (stopped_) {
+    return;
+  }
+  
+  std::shared_ptr<DuplicateMsg> msg = std::make_shared<DuplicateMsg>(
+    write_op_state_ptr,
+    row_op, schema, 
+    table_name_);
+  queue_.Put(msg);
+  WARN_NOT_OK(duplicate_pool_token_->Submit(
+      [this]() { this->Apply(); }),
+      "duplicator apply failed");
+}
+
+void Duplicator::Apply() {
+  std::vector<std::shared_ptr<DuplicateMsg>> msgs;
+  queue_.BlockingDrainTo(&msgs, MonoTime::Now() + MonoDelta::FromSeconds(30));
+  if (!msgs.empty()) {
+    LOG(INFO) << "msg size: " << msgs.size();
+    // sync call
+    Status s = connector_->WriteBatch(msgs);
+    if (s.ok()) {
+      auto rit = msgs.rbegin();
+      {
+        std::lock_guard<std::mutex> l(mutex_);
+        last_confirmed_opid_ = (*rit)->op_state->op_id();
+      }
+      LOG(INFO) << "duplicator confirmed opid: (" << last_confirmed_opid_.term() << "," 
+        << last_confirmed_opid_.index() << ")";
+    }
+  }
+}
+
+}  // namespace duplicator
+}  // namespace kudu
+
+/* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/src/kudu/duplicator/duplicator.h
+++ b/src/kudu/duplicator/duplicator.h
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// The file define a Duplicator, it contains common logic codes, 
+// User shoud pick Connector what you want.
+
+#pragma once
+
+#include <memory>
+
+#include "kudu/consensus/opid.pb.h"
+#include "kudu/duplicator/connector.h"
+#include "kudu/tablet/ops/write_op.h"
+#include "kudu/util/blocking_queue.h"
+#include "kudu/util/memory/arena.h"
+#include "kudu/util/status.h"
+
+namespace kudu {
+class Schema;
+class ThreadPool;
+class ThreadPoolToken;
+namespace tablet {
+class Tablet;
+struct RowOp;
+}  // namespace tablet
+
+namespace duplicator {
+
+class Duplicator {
+public:
+    Duplicator(ThreadPool* thread_pool, const std::string& table_name);
+    ~Duplicator();
+    Duplicator(const Duplicator& /* dup */) = delete;
+    void operator=(const Duplicator& /* dup */) = delete;
+
+    Status Init();
+    Status Shutdown();
+
+    void Duplicate(const std::shared_ptr<tablet::WriteOpState>& op_state_ptr, 
+                   const tablet::RowOp* row_op, const std::shared_ptr<Schema>& schema);
+    void Apply();
+    const consensus::OpId last_confirmed_opid() const {
+        std::lock_guard<std::mutex> l(mutex_);
+        return last_confirmed_opid_;
+    }
+private:
+    ThreadPool* duplicate_pool_;
+    // std::shared_ptr<tablet::Tablet> tablet_;
+    const std::string table_name_;
+    consensus::OpId last_confirmed_opid_;
+    mutable std::mutex mutex_;
+    bool stopped_;
+    // TODO use pointer to avoid copy
+    BlockingQueue<std::shared_ptr<DuplicateMsg>> queue_;
+
+    // Singleton, eg KafkaConnector
+    Connector* connector_;
+    std::unique_ptr<ThreadPoolToken> duplicate_pool_token_;
+};
+
+} // namespace duplicator
+} // namespace kudu
+
+/* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/src/kudu/duplicator/kafka/kafka.proto
+++ b/src/kudu/duplicator/kafka/kafka.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package kudu.kafka;
+
+message RawProperty {
+  string name = 1;
+  string value = 2;
+  bool primary_key_column = 3;
+  bool null_value = 4;
+}
+
+// kudu 数据描述
+message RawKuduRecord {
+  string user_id = 1 [deprecated = true];
+  string project_id = 2 [deprecated = true];
+  string table_name = 4;
+  repeated RawProperty properties = 3;
+
+  enum KuduOperationType {
+    KUDU_OPERATION_TYPE_UNSPECIFIED = 0;
+    // 新增或者修改
+    SET = 1;
+    // 数据删除
+    DELETE = 2;
+  }
+  KuduOperationType operation_type = 5;
+}

--- a/src/kudu/duplicator/kafka/kafka_connector-test.cc
+++ b/src/kudu/duplicator/kafka/kafka_connector-test.cc
@@ -1,0 +1,241 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "kudu/duplicator/kafka/kafka_connector.h"
+
+#include <cppkafka/exceptions.h>
+#include <stdint.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <glog/logging.h>
+#include <google/protobuf/arena.h>
+#include <gtest/gtest.h>
+
+#include "kudu/common/common.pb.h"
+#include "kudu/common/partial_row.h"
+#include "kudu/common/row_operations.h"
+#include "kudu/common/schema.h"
+#include "kudu/common/wire_protocol.pb.h"
+#include "kudu/duplicator/connector.h"
+#include "kudu/duplicator/kafka/kafka.pb.h"
+#include "kudu/duplicator/kafka/mock_kafka_connector.h"
+#include "kudu/tablet/row_op.h"
+#include "kudu/util/memory/arena.h"
+#include "kudu/util/slice.h"
+#include "kudu/util/status.h"
+#include "kudu/util/test_macros.h"
+#include "kudu/util/test_util.h"
+
+namespace kudu {
+class RowChangeList;
+}  // namespace kudu
+
+using std::make_shared;
+
+namespace kudu {
+namespace duplicator {
+
+class KafkaConnectorTest : public KuduTest {
+ public:
+  KafkaConnectorTest()
+      : KuduTest(),
+        schema_(GetSimpleSchema()),
+        client_schema_(schema_.CopyWithoutColumnIds()),
+        arena_(256 * 1024) {
+    mock_connector_ = kafka::KafkaConnector<cppkafka::MockProducer>::GetInstance();
+    connector_ = kafka::KafkaConnector<cppkafka::Producer>::GetInstance();
+  }
+  void SetUp() {}
+  void TearDown() {}
+
+  Schema GetSimpleSchema() {
+    SchemaBuilder builder;
+    builder.AddKeyColumn("k_int8", INT8);
+    builder.AddKeyColumn("k_int16", INT16);
+    builder.AddKeyColumn("k_int32", INT32);
+    builder.AddKeyColumn("k_int64", INT64);
+    builder.AddKeyColumn("k_string", STRING);
+    builder.AddKeyColumn("k_binary", BINARY);
+    builder.AddKeyColumn("k_timestamp", UNIXTIME_MICROS);
+
+    // nullable default: false
+    builder.AddColumn("v_int8", INT8, false, nullptr, nullptr);
+    builder.AddColumn("v_int16", INT16, false, nullptr, nullptr);
+    builder.AddColumn("v_int32", INT32, false, nullptr, nullptr);
+    builder.AddColumn("v_int64", INT64, false, nullptr, nullptr);
+    builder.AddColumn("v_string", STRING, false, nullptr, nullptr);
+    builder.AddColumn("v_binary", BINARY, false, nullptr, nullptr);
+    builder.AddColumn("v_timestamp", UNIXTIME_MICROS, false, nullptr, nullptr);
+
+    int32_t default_read = -1;
+    int16_t default_write = 0;
+    kudu::Slice default_read_str("read_empty");
+    kudu::Slice default_write_str("write_empty");
+    builder.AddColumn("vn_int8", INT8, true, nullptr, nullptr);
+    builder.AddColumn("vn_int16", INT16, true, nullptr, &default_write);
+    builder.AddColumn("vn_int32", INT32, true, &default_read, nullptr);
+    builder.AddColumn("vn_int64", INT64, true, nullptr, nullptr);
+    builder.AddColumn("vn_string", STRING, true, &default_read_str, nullptr);
+    builder.AddColumn("vn_binary", BINARY, true, nullptr, &default_write_str);
+    builder.AddColumn("vn_timestamp", UNIXTIME_MICROS, true, nullptr, nullptr);
+
+    return builder.Build();
+  }
+
+  Status GenDecodedRowOperation(std::vector<DecodedRowOperation>* ops) {
+    int8_t int8_expected = 0xF0;
+    int16_t int16_expected = 0xFFF0;
+    int32_t int32_expected = 0xFFFFF0;
+    int64_t int64_expected = 0xFFFFFFFF0;
+
+    kudu::RowOperationsPB pb;
+    RowOperationsPBEncoder encoder(&pb);
+
+    int count = 0;
+    RowOperationsPB::Type type_list[] = {RowOperationsPB::INSERT,
+                                         RowOperationsPB::UPDATE,
+                                         RowOperationsPB::DELETE,
+                                         RowOperationsPB::UPSERT,
+                                         RowOperationsPB::INSERT_IGNORE,
+                                         RowOperationsPB::UPDATE_IGNORE,
+                                         RowOperationsPB::DELETE_IGNORE};
+    for (RowOperationsPB::Type type : type_list) {
+      count++;
+      kudu::KuduPartialRow* row_ptr = new kudu::KuduPartialRow(&client_schema_);
+      kudu::KuduPartialRow& row = *row_ptr;
+      CHECK_OK(row.SetInt8("k_int8", int8_expected + static_cast<int8_t>(count)));
+      CHECK_OK(row.SetInt16("k_int16", int16_expected + static_cast<int16_t>(count)));
+      CHECK_OK(row.SetInt32("k_int32", int32_expected + static_cast<int32_t>(count)));
+      CHECK_OK(row.SetInt64("k_int64", int64_expected + static_cast<int64_t>(count)));
+      CHECK_OK(row.SetStringNoCopy("k_string", "string-value"));
+      CHECK_OK(row.SetBinaryNoCopy("k_binary", "binary-value"));
+      CHECK_OK(row.SetUnixTimeMicros("k_timestamp", 10009));
+
+      CHECK_OK(row.SetInt8("v_int8", int8_expected));
+      CHECK_OK(row.SetInt16("v_int16", int16_expected));
+      CHECK_OK(row.SetInt32("v_int32", int32_expected));
+      CHECK_OK(row.SetInt64("v_int64", int64_expected));
+      CHECK_OK(row.SetStringNoCopy("v_string", "string-value"));
+      CHECK_OK(row.SetBinaryNoCopy("v_binary", "binary-value"));
+      CHECK_OK(row.SetUnixTimeMicros("v_timestamp", 10009));
+
+      CHECK_OK(row.SetInt8("vn_int8", int8_expected + static_cast<int32_t>(count)));
+      CHECK_OK(row.SetInt64("vn_int64", int64_expected + static_cast<int64_t>(count)));
+      CHECK_OK(row.SetBinaryNoCopy("vn_binary", "binary-value"));
+      encoder.Add(type, row);
+    }
+    RowOperationsPBDecoder decoder(&pb, &client_schema_, &schema_, &arena_);
+    decoder.DecodeOperations<DecoderMode::WRITE_OPS>(ops);
+    return Status::OK();
+  }
+  Status GenRowChangeList(RowChangeList* change_list) { return Status::OK(); }
+
+ public:
+  Schema schema_;
+  Schema client_schema_;
+  Arena arena_;
+  Connector* mock_connector_;
+  Connector* connector_;
+};
+
+using kudu::kafka::RawKuduRecord;
+
+TEST_F(KafkaConnectorTest, ParseRow) {
+  std::vector<DecodedRowOperation> ops;
+  GenDecodedRowOperation(&ops);
+  ASSERT_EQ(7, ops.size());
+
+  RawKuduRecord record1;
+  uint64_t code1 = 0;
+  ASSERT_TRUE(kafka::ParseRow(ops[0], &schema_, &record1, &code1).ok());
+
+  for (int i = 1; i < 7; i++) {
+    RawKuduRecord record2;
+    uint64_t code2 = 0;
+    uint64_t code3 = 0;
+    ASSERT_TRUE(kafka::ParseRow(ops[i], &schema_, &record2, &code2).ok());
+    kudu::SleepFor(kudu::MonoDelta::FromMilliseconds(100));
+    ASSERT_TRUE(kafka::ParseRow(ops[i], &schema_, &record2, &code3).ok());
+    ASSERT_EQ(code2, code3);
+  }
+}
+
+TEST_F(KafkaConnectorTest, KafkaProducerMockTest) {
+  arena_.Reset();
+
+  std::vector<DecodedRowOperation> ops;
+  GenDecodedRowOperation(&ops);
+  std::vector<tablet::RowOp*> row_ops;
+  row_ops.reserve(ops.size());
+  for (auto& op : ops) {
+    google::protobuf::Arena pb_arena;
+    row_ops.emplace_back(arena_.NewObject<tablet::RowOp>(&pb_arena, std::move(op)));
+  }
+
+  std::shared_ptr<Schema> schema_ptr(new Schema(schema_));
+  std::string table_name("bailing");
+
+  std::vector<std::shared_ptr<duplicator::DuplicateMsg>> messages;
+  std::shared_ptr<tablet::WriteOpState> empty_ptr;
+  for (auto& row_op : row_ops) {
+    std::shared_ptr<duplicator::DuplicateMsg> dup_msg =
+      std::make_shared<duplicator::DuplicateMsg>(empty_ptr, row_op, schema_ptr, table_name);
+    messages.emplace_back(dup_msg);
+  }
+
+  LOG(INFO) << "kafka mock connector running, mock write";
+  ASSERT_OK(mock_connector_->WriteBatch(messages));
+}
+
+TEST_F(KafkaConnectorTest, KafkaProducerWritebatchTest) {
+  arena_.Reset();
+  connector_->InitPrepare();
+
+  std::vector<DecodedRowOperation> ops;
+  GenDecodedRowOperation(&ops);
+  std::vector<tablet::RowOp*> row_ops;
+  row_ops.reserve(ops.size());
+  for (auto& op : ops) {
+    google::protobuf::Arena pb_arena;
+    row_ops.emplace_back(arena_.NewObject<tablet::RowOp>(&pb_arena, std::move(op)));
+  }
+
+  std::shared_ptr<Schema> schema_ptr(new Schema(schema_));
+  std::string table_name("bailing");
+
+  std::vector<std::shared_ptr<duplicator::DuplicateMsg>> messages;
+  std::shared_ptr<tablet::WriteOpState> empty_ptr;
+  for (auto& row_op : row_ops) {
+    std::shared_ptr<duplicator::DuplicateMsg> dup_msg =
+      std::make_shared<duplicator::DuplicateMsg>(empty_ptr, row_op, schema_ptr, table_name);
+    messages.emplace_back(dup_msg);
+  }
+
+  LOG(INFO) << "kafka connector running, write to kafka";
+  ASSERT_OK(connector_->Init());
+  ASSERT_OK(connector_->TestBasicClientApi("write kafka basic test"));
+  ASSERT_OK(connector_->WriteBatch(messages));
+}
+
+
+}  // namespace duplicator
+}  // namespace kudu

--- a/src/kudu/duplicator/kafka/kafka_connector.cc
+++ b/src/kudu/duplicator/kafka/kafka_connector.cc
@@ -1,0 +1,113 @@
+#include "kudu/duplicator/kafka/kafka_connector.h"
+
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include "kudu/common/row.h"
+#include "kudu/common/row_changelist.h"
+#include "kudu/common/row_operations.h"
+#include "kudu/common/wire_protocol.pb.h"
+#include "kudu/duplicator/kafka/kafka.pb.h"
+#include "kudu/gutil/strings/substitute.h"
+#include "kudu/util/slice.h"
+
+namespace cppkafka {
+class Producer;
+}  // namespace cppkafka
+
+using cppkafka::Configuration;
+using cppkafka::Exception;
+using cppkafka::MessageBuilder;
+using cppkafka::Metadata;
+using cppkafka::Producer;
+using kudu::kafka::RawKuduRecord;
+using std::make_shared;
+using std::shared_ptr;
+using std::string;
+using std::vector;
+using strings::Substitute;
+
+DEFINE_string(kafka_broker_list, "localhost:9092", "");
+DEFINE_string(kafka_target_topic, "kudu_profile_record_stream", "");
+DEFINE_int32(kafka_retry_num, 3, "kafka api retry num if failed");
+
+// support kerberos, detail in https://github.com/edenhill/librdkafka/wiki/Using-SASL-with-librdkafka,
+// the page's the 5th part: 5.Configure Kafka client on client host
+DEFINE_string(security_protocol, "SASL_PLAINTEXT", "security protocol, such as PLAINTEXT,SSL,SASL_PLAINTEXT,SASL_SSL");
+DEFINE_string(keytab_full_path, "", "keytab file's full path");
+DEFINE_string(principal_name, "", "principal info, your should input correct info");
+
+DEFINE_int32(min_topic_partition_num, 1, "the min value of topic's partition num");
+
+namespace kudu {
+namespace kafka {
+
+Status ParseRow(const DecodedRowOperation& decoded_row,
+                const Schema* schema,
+                RawKuduRecord* insert_value_pb,
+                uint64_t* primary_key_hash_code) {
+  ConstContiguousRow parsed_row = ConstContiguousRow(schema, decoded_row.row_data);
+
+  RangePKToPB(*schema, parsed_row, insert_value_pb, primary_key_hash_code);
+
+  if (decoded_row.type == RowOperationsPB::DELETE || 
+      decoded_row.type == RowOperationsPB::DELETE_IGNORE) {
+    // When deleting, only key is needed;
+    return Status::OK();
+  }
+  if (decoded_row.type == RowOperationsPB::UPDATE || 
+      decoded_row.type == RowOperationsPB::UPDATE_IGNORE) {
+    // When updating, the value's data is stored in changelist instead.
+    return ChangesToColumn(decoded_row.changelist, schema, insert_value_pb);
+  }
+  // The operations below are insert/upsert.
+  RangeToPB(*schema, parsed_row, decoded_row.isset_bitmap, insert_value_pb);
+  return insert_value_pb->properties().empty() ? 
+             Status::Corruption("range to pb error") : Status::OK();
+}
+
+Status ChangesToColumn(const RowChangeList& changelist,
+                       const Schema* schema,
+                       RawKuduRecord* update_value_pb) {
+  DCHECK_GT(changelist.slice().size(), 0);
+  RowChangeListDecoder decoder(changelist);
+  Status s = decoder.Init();
+
+  while (decoder.HasNext()) {
+    RowChangeListDecoder::DecodedUpdate dec;
+    int col_idx;
+    const void* value;
+    s = decoder.DecodeNext(&dec);
+    if (s.ok()) {
+      s = dec.Validate(*schema, &col_idx, &value);
+    } else {
+      // invalid record
+      return update_value_pb->properties().empty() ? 
+              Status::Corruption("invalid record") : Status::OK();
+    }
+    // Known column.
+    const ColumnSchema& col_schema = schema->column(col_idx);
+    RawProperty* property = update_value_pb->add_properties();
+    property->set_primary_key_column(false);
+    property->set_name(col_schema.name());
+
+    if (value != nullptr) {
+      string ret;
+      col_schema.type_info()->StringForValue(value, &ret);
+      property->set_null_value(false);
+      property->set_value(ret);
+    } else {
+      property->set_value("");
+      property->set_null_value(true);
+    }
+  }
+
+  return update_value_pb->properties().empty() ? 
+            Status::Corruption("range to pb error") : Status::OK();
+}
+
+}  // namespace kafka
+}  // namespace kudu

--- a/src/kudu/duplicator/kafka/kafka_connector.h
+++ b/src/kudu/duplicator/kafka/kafka_connector.h
@@ -1,0 +1,296 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// the codes based on some ningw's internal work, and then refact.
+//
+
+#pragma once
+
+#include <cppkafka/configuration.h>
+#include <cppkafka/exceptions.h>
+#include <cppkafka/message_builder.h>
+#include <cppkafka/metadata.h>
+#include <cppkafka/producer.h>
+
+#include <stdint.h>
+
+#include <chrono>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gflags/gflags_declare.h>
+#include <glog/logging.h>
+
+#include "kudu/common/schema.h"
+#include "kudu/common/types.h"
+#include "kudu/duplicator/connector.h"
+#include "kudu/duplicator/kafka/kafka.pb.h"
+#include "kudu/gutil/hash/city.h"
+#include "kudu/gutil/singleton.h"
+#include "kudu/gutil/strings/substitute.h"
+#include "kudu/tablet/row_op.h"
+#include "kudu/util/bitmap.h"
+#include "kudu/util/status.h"
+
+namespace kudu {
+class RowChangeList;
+struct DecodedRowOperation;
+}  // namespace kudu
+
+DECLARE_string(kafka_broker_list);
+DECLARE_string(kafka_target_topic);
+DECLARE_int32(kafka_retry_num);
+DECLARE_string(downstream_type);
+
+DECLARE_string(security_protocol);
+DECLARE_string(keytab_full_path);
+DECLARE_string(principal_name);
+DECLARE_int32(min_topic_partition_num);
+
+using std::map;
+using std::string;
+
+namespace kudu {
+namespace kafka {
+
+extern Status ParseRow(const DecodedRowOperation& decoded_row,
+                    const Schema* schema,
+                    RawKuduRecord* insert_value_pb,
+                    uint64_t* primary_key_hash_code);
+extern Status ChangesToColumn(const RowChangeList& changelist,
+                           const Schema* schema,
+                           RawKuduRecord* update_value_pb);
+template <class RowType>
+void RangeToPB(const Schema& schema,
+               const RowType& row,
+               const uint8_t* isset_bitmap,
+               kudu::kafka::RawKuduRecord* insert_value_pb) {
+  int low = schema.num_key_columns();
+  int high = schema.num_columns();
+  for (int i = low; i < high; ++i) {
+    if (!BitmapTest(isset_bitmap, i)) {
+      continue;
+    }
+    const ColumnSchema& col = schema.column(i);
+    auto* property = insert_value_pb->add_properties();
+    if (col.is_nullable() && row.cell(i).is_null()) {
+      property->set_value("");
+      property->set_null_value(true);
+    } else {
+      property->set_null_value(false);
+      std::string ret;
+      col.type_info()->StringForValue(row.cell(i).ptr(), &ret);
+      property->set_value(ret);
+    }
+    property->set_name(col.name());
+    property->set_primary_key_column(false);
+  }
+}
+
+template <class RowType>
+void RangePKToPB(const Schema& schema,
+                 const RowType& row,
+                 kudu::kafka::RawKuduRecord* insert_value_pb,
+                 uint64_t* primary_key_hash_code) {
+  int pk_num = schema.num_key_columns();
+  std::string primary_key;
+  for (int i = 0; i < pk_num; ++i) {
+    const ColumnSchema& col = schema.column(i);
+    std::string ret;
+    col.type_info()->StringForValue(row.cell(i).ptr(), &ret);
+    auto* property = insert_value_pb->add_properties();
+    property->set_name(col.name());
+    property->set_value(ret);
+    property->set_primary_key_column(true);
+    property->set_null_value(false);
+    primary_key.append(ret);
+  }
+  *primary_key_hash_code = util_hash::CityHash64(primary_key.data(), primary_key.size());
+}
+
+template <typename T>
+class KafkaConnector : public duplicator::RemoteConnector {
+ public:
+  static KafkaConnector<T>* GetInstance() {
+    if (FLAGS_downstream_type != "kafka") {
+      return nullptr;
+    }
+    return Singleton<KafkaConnector<T>>::get();
+  }
+
+  virtual Status InitPrepare() override {
+    cppkafka::Configuration configuration = {{"metadata.broker.list", FLAGS_kafka_broker_list}};
+
+    if (FLAGS_keytab_full_path.empty() != FLAGS_principal_name.empty()) {
+      LOG(FATAL) << "keytab_full_path and principal_name flags should"
+          "set together or default together";
+    }
+    if (!FLAGS_keytab_full_path.empty()) {
+      configuration.set("security.protocol", FLAGS_security_protocol);
+      configuration.set("sasl.kerberos.keytab", FLAGS_keytab_full_path);
+      configuration.set("sasl.kerberos.principal", FLAGS_principal_name);
+    }
+
+    auto producer = std::make_shared<T>(configuration);
+    producer_.swap(producer);
+    return Status::OK();
+  }
+
+  virtual Status Init() override {
+    if (inited_) {
+      return Status::OK();
+    }
+    MutexLock l(init_lock_);
+    if (inited_) {
+      return Status::OK();
+    }
+    InitPrepare();
+    try {
+      cppkafka::Metadata metadata = producer_->get_metadata();
+      bool found = false;
+      // The topic should have been created at program running envs
+      bool partition_num_valid = false;
+      for (const auto& topic : metadata.get_topics()) {
+        if (topic.get_name() == FLAGS_kafka_target_topic) {
+          found = true;
+          if (topic.get_partitions().size() >= FLAGS_min_topic_partition_num) {
+            partition_num_valid = true;
+          }
+          break;
+        }
+      }
+      if (!found) {
+        // topic not found
+        std::string s = strings::Substitute("topic $0 not exist", FLAGS_kafka_target_topic);
+        LOG(ERROR) << s;
+        return Status::Aborted(s);
+      }
+      if (!partition_num_valid) {
+        std::string s = strings::Substitute("topic $0 partition num should more than $1",
+                                            FLAGS_kafka_target_topic,
+                                            FLAGS_min_topic_partition_num);
+        LOG(ERROR) << s;
+        return Status::Aborted(s);
+      }
+    } catch (const cppkafka::Exception& e) {
+      LOG(ERROR) << "check whether topic: " << FLAGS_kafka_target_topic << " exists";
+      LOG(ERROR) << "check whether broker list " << FLAGS_kafka_broker_list << " is right";
+      return Status::Corruption(
+          strings::Substitute("check whether topic $0 exists or broker $1 works fine",
+                              FLAGS_kafka_target_topic,
+                              FLAGS_kafka_broker_list));
+    }
+
+    LOG(INFO) << "kafka producer init succeed!";
+    inited_ = true;
+    return Status::OK();
+  }
+
+  // consume content in kafka_record_queue and flush to kafka
+  virtual Status WriteBatch(
+      const std::vector<std::shared_ptr<duplicator::DuplicateMsg>>& messages) override {
+    if (messages.empty()) {
+      return Status::OK();
+    }
+    for (const auto& entry : messages) {
+      kudu::kafka::RawKuduRecord record;
+      uint64_t primary_key_hash_code = 0;
+      RETURN_NOT_OK(ParseRow(entry->row_op->decoded_op, entry->schema_ptr.get(), 
+                             &record, &primary_key_hash_code));
+      record.set_table_name(std::move(entry->table_name));
+      switch (entry->row_op->decoded_op.type) {
+        case RowOperationsPB::INSERT:
+        case RowOperationsPB::INSERT_IGNORE:
+        case RowOperationsPB::UPSERT:
+        case RowOperationsPB::UPDATE:
+        case RowOperationsPB::UPDATE_IGNORE:
+          record.set_operation_type(kudu::kafka::RawKuduRecord::SET);
+          break;
+        case RowOperationsPB::DELETE:
+        case RowOperationsPB::DELETE_IGNORE:
+          record.set_operation_type(kudu::kafka::RawKuduRecord::DELETE);
+          break;
+        default:
+          LOG(WARNING) << "unknown RowOperationsPB type" << 
+            RowOperationsPB::Type_Name(entry->row_op->decoded_op.type);
+          break;
+      }
+      
+      std::string hash_key(reinterpret_cast<const char*>(&primary_key_hash_code), sizeof(uint64_t));
+      std::string json_data;
+      record.SerializeToString(&json_data);
+      const auto& message = cppkafka::MessageBuilder(FLAGS_kafka_target_topic)
+                                .key(hash_key)
+                                .payload(json_data);
+
+      try {
+        producer_->produce(message);
+      } catch (const cppkafka::Exception& e) {
+        LOG(WARNING) << "produce message failed";
+        return Status::ServiceUnavailable("kafka client produce failed");
+      }
+    }
+
+    try {
+      producer_->flush(flush_timeout_ms_);
+      return Status::OK();
+    } catch (const cppkafka::Exception& e) {
+      LOG(WARNING) << "failed when flushing: " << e.what();
+    }
+
+    return Status::ServiceUnavailable("flush messages failed");
+  }
+
+  virtual Status TestBasicClientApi(const std::string& msg) override {
+    const auto& message =
+        cppkafka::MessageBuilder(FLAGS_kafka_target_topic)
+            .key("hello world")
+            .payload(msg);
+    try {
+      producer_->produce(message);
+    } catch (const cppkafka::Exception& e) {
+      return Status::IOError("basic produce error");
+    }
+    try {
+      producer_->flush(flush_timeout_ms_);
+    } catch (const cppkafka::Exception& e) {
+      return Status::IOError("basic flush error");
+    }
+
+    return Status::OK();
+  }
+
+ protected:
+  KafkaConnector() : duplicator::RemoteConnector(), flush_timeout_ms_(10000) {}
+  virtual ~KafkaConnector() {}
+  friend class Singleton<KafkaConnector>;
+  std::chrono::milliseconds flush_timeout_ms_;
+
+ protected:
+  // cppkafka::Producer, cppkafka::MockProducer
+  std::shared_ptr<T> producer_;
+
+  mutable Mutex init_lock_;
+  bool inited_ = false;
+};
+
+}  // namespace kafka
+}  // namespace kudu

--- a/src/kudu/duplicator/kafka/mock_kafka_connector.h
+++ b/src/kudu/duplicator/kafka/mock_kafka_connector.h
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// The file is for mock unit test.
+
+#include "cppkafka/cppkafka.h"
+
+DECLARE_string(kafka_broker_list);
+DECLARE_string(kafka_target_topic);
+DECLARE_int32(kafka_retry_num);
+DECLARE_string(downstream_type);
+
+namespace cppkafka {
+
+class MockProducer {
+ public:
+  explicit MockProducer(Configuration config) : timeout_ms_(30000) {}
+
+  Metadata get_metadata() {
+    Metadata meta;
+    return meta;
+  }
+  int timeout_ms() { return timeout_ms_; }
+
+  // cppkafka::MessageBuilder
+  void produce(const MessageBuilder& message) { produce(message, false); }
+  void produce(const MessageBuilder& /* message */, bool fail_injection) {
+    rd_kafka_resp_err_t error = RD_KAFKA_RESP_ERR_NO_ERROR;
+    if (fail_injection) {
+      error = RD_KAFKA_RESP_ERR_INVALID_MSG;
+    }
+    check_error(error);
+  }
+
+  void flush() { flush(std::chrono::milliseconds(timeout_ms_), false); }
+  void flush(bool fail_injection) { flush(std::chrono::milliseconds(timeout_ms_), fail_injection); }
+
+  /**
+   * \brief Mock Flush all outstanding produce requests
+   * \param timeout The timeout used on this call
+   */
+  void flush(std::chrono::milliseconds timeout) { flush(timeout, false); }
+  void flush(std::chrono::milliseconds timeout, bool fail_injection) {
+    rd_kafka_resp_err_t error = RD_KAFKA_RESP_ERR_NO_ERROR;
+    if (fail_injection) {
+      error = RD_KAFKA_RESP_ERR_INVALID_MSG;
+    }
+    check_error(error);
+  }
+  void check_error(rd_kafka_resp_err_t error) {
+    if (error != RD_KAFKA_RESP_ERR_NO_ERROR) {
+      throw HandleException(error);
+    }
+  }
+
+ private:
+  int timeout_ms_;
+};
+}  // namespace cppkafka

--- a/src/kudu/integration-tests/CMakeLists.txt
+++ b/src/kudu/integration-tests/CMakeLists.txt
@@ -163,3 +163,6 @@ endif()
 
 # Tests that should not be run automatically by ctest.
 ADD_KUDU_TEST_NO_CTEST(version_migration-test)
+
+SET_KUDU_TEST_LINK_LIBS(itest_util gumbo-parser gumbo-query kafka)
+ADD_KUDU_TEST(duplication_with_kafka-itest)

--- a/src/kudu/integration-tests/duplication_with_kafka-itest.cc
+++ b/src/kudu/integration-tests/duplication_with_kafka-itest.cc
@@ -1,0 +1,366 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "kudu/integration-tests/external_mini_cluster-itest-base.h"
+#include "kudu/mini-cluster/internal_mini_cluster.h"
+
+#include <memory>
+
+#include <cppkafka/configuration.h>
+#include <cppkafka/exceptions.h>
+#include <cppkafka/message_builder.h>
+#include <cppkafka/metadata.h>
+#include <cppkafka/consumer.h>
+
+#include "kudu/client/callbacks.h"
+#include "kudu/client/client.h"
+#include "kudu/client/schema.h"
+#include "kudu/client/row_result.h"
+#include "kudu/client/value.h"
+#include "kudu/client/write_op.h"
+
+#include "kudu/common/partial_row.h"
+#include "kudu/util/test_macros.h"
+
+namespace kudu {
+
+struct CreateTableOptions {
+  std::string table_name;
+  int32_t partition_num;
+  int32_t replica_refactor;
+  client::DuplicationInfo dup_info;
+};
+
+enum class Action {
+  kEnableDuplication = 0,
+  kDisableDuplication
+};
+
+struct AlterTableOptions {
+  Action action;
+  std::string table_name;
+  client::DuplicationInfo info;
+};
+// Simple base utility class to provide an external mini cluster with common
+// setup routines useful for integration tests. And start kafka service to test
+// data duplication.
+class DuplicationITest : public ExternalMiniClusterITestBase {
+public:
+  DuplicationITest() : schema_(SimpleKuduSchema()) {
+    cluster_opts_.num_tablet_servers = 4;
+    cluster_opts_.enable_duplication = true;
+
+    // cluster_opts_.extra_master_flags.emplace_back("--v=64");
+    // cluster_opts_.extra_tserver_flags.emplace_back("--v=64");
+    options_.partition_num = 4;
+    options_.replica_refactor = 3;
+    options_.table_name = "duplication_table";
+  }
+  void SetUp() override {
+    NO_FATALS(StartClusterWithOpts(cluster_opts_));
+    DestroyKafka();
+    InitKafka();
+  }
+  void TearDown() override {
+    ExternalMiniClusterITestBase::TearDown();
+    DestroyKafka();
+  }
+
+
+  void Consume(int expected_size) {
+    std::chrono::milliseconds timeout(5000);
+    int count = 0;
+    int max_batch_size = 4;
+    std::vector<cppkafka::Message> messages;
+    while (true) {
+      messages.clear();
+      messages = consumer_->poll_batch(max_batch_size, timeout);
+      for (const auto& msg : messages) {
+        if (msg) {
+          if (msg.get_error()) {
+            if (!msg.is_eof()) {
+              LOG(INFO) << "Received error notification: " << msg.get_error();
+            }
+          } else {
+            if (msg.get_key()) {
+              LOG(INFO) << "kafka key: " << msg.get_key();
+            }
+            LOG(INFO) << "kafka payload: " << msg.get_payload();
+            consumer_->commit(msg);
+            count++;
+          }
+        }
+      }
+      if (expected_size == count) {
+        break;
+      }
+    }
+    
+    messages.clear();
+    messages = consumer_->poll_batch(max_batch_size, timeout);
+    ASSERT_TRUE(messages.size() == 0);
+  }
+
+protected:
+  void InitKafka() {
+    std::string start_cmd = "sh /tmp/kafka-simple-control.sh start";
+    int ret = system(start_cmd.c_str());
+    if (ret != 0) {
+      LOG(FATAL) << "start kafka failed";
+    }
+
+    cppkafka::Configuration configuration = {
+      { "metadata.broker.list", "localhost:9092" },
+      { "group.id", "default" },
+      { "enable.auto.commit", false }
+    };
+
+    consumer_ = std::make_shared<cppkafka::Consumer>(configuration);
+
+    // Print the assigned partitions on assignment
+    consumer_->set_assignment_callback([](const cppkafka::TopicPartitionList& partitions) {
+      LOG(INFO) << "Got assigned: " << partitions;
+    });
+
+    // Print the revoked partitions on revocation
+    consumer_->set_revocation_callback([](const cppkafka::TopicPartitionList& partitions) {
+      LOG(INFO)  << "Got revoked: " << partitions;
+    });
+
+    consumer_->subscribe({ "kudu_profile_record_stream" });
+  }
+
+  void DestroyKafka() {
+    std::string stop_cmd = "sh /tmp/kafka-simple-control.sh stop";
+    int ret = system(stop_cmd.c_str());
+    if (ret != 0) {
+      LOG(FATAL) << "stop kafka failed";
+    }
+  }
+
+  Status CreateTable() {
+    return CreateTable(options_, false);
+  }
+  
+  Status CreateTable(const CreateTableOptions& options, bool has_duplication) {
+    std::unique_ptr<client::KuduTableCreator> table_creator(client_->NewTableCreator());
+    if (has_duplication) {
+      RETURN_NOT_OK(table_creator->table_name(options.table_name)
+                    .schema(&schema_)
+                    .add_hash_partitions({ "key" }, options.partition_num)
+                    .num_replicas(options.replica_refactor)
+                    .duplication(options.dup_info)
+                    .Create());
+    } else {
+      RETURN_NOT_OK(table_creator->table_name(options.table_name)
+                    .schema(&schema_)
+                    .add_hash_partitions({ "key" }, options.partition_num)
+                    .num_replicas(options.replica_refactor)
+                    .Create());
+    }
+
+    RETURN_NOT_OK(client_->OpenTable(options.table_name, &table_));
+    bool is_creating = true;
+    while (is_creating) {
+      client_->IsCreateTableInProgress(options.table_name, &is_creating);
+      SleepFor(MonoDelta::FromMilliseconds(1000));
+    }
+    LOG(INFO) << "create table "<< options.table_name << " done";
+    return Status::OK();
+  }
+
+  Status AlterTable(const AlterTableOptions& options) {
+    client::KuduTableAlterer* table_alterer = client_->NewTableAlterer(options.table_name);
+    if (options.action == Action::kEnableDuplication) {
+      table_alterer->AddDuplicationInfo(options.info);
+    } else {
+      table_alterer->DropDuplicationInfo(options.info);
+    }
+    RETURN_NOT_OK(table_alterer->Alter());
+    delete table_alterer;
+    bool is_altering = true;
+    while (is_altering) {
+      client_->IsAlterTableInProgress(options.table_name, &is_altering);
+      SleepFor(MonoDelta::FromMilliseconds(1000));
+    }
+    LOG(INFO) << "alter table "<< options.table_name << " done";
+    return Status::OK();
+  }
+
+  Status DeleteTable(const std::string& table_name) {
+    return client_->DeleteTable(table_name);
+  }
+
+  static void StatusCB(void* unused, const Status& status) {
+    KUDU_LOG(INFO) << "Asynchronous flush finished with status: "
+                  << status.ToString();
+  }
+
+  Status InsertRows(int num_rows) {
+    client::sp::shared_ptr<client::KuduSession> session = table_->client()->NewSession();
+    KUDU_RETURN_NOT_OK(session->SetFlushMode(client::KuduSession::MANUAL_FLUSH));
+    session->SetTimeoutMillis(5000);
+
+    for (int i = 0; i < num_rows; i++) {
+      client::KuduInsert* insert = table_->NewInsert();
+      KuduPartialRow* row = insert->mutable_row();
+      KUDU_CHECK_OK(row->SetInt32("key", i));
+      KUDU_CHECK_OK(row->SetString("value_string", std::to_string(i * 2)));
+      // KUDU_CHECK_OK(row->SetInt64("value_string", static_cast<int64_t>(i * 3)));
+      KUDU_CHECK_OK(session->Apply(insert));
+    }
+    Status s = session->Flush();
+    if (s.ok()) {
+      return s;
+    }
+
+    // Test asynchronous flush.
+    client::KuduStatusFunctionCallback<void*> status_cb(&StatusCB, NULL);
+    session->FlushAsync(&status_cb);
+
+    // Look at the session's errors.
+    std::vector<client::KuduError*> errors;
+    bool overflow;
+    session->GetPendingErrors(&errors, &overflow);
+    if (!errors.empty()) {
+      s = overflow ? Status::IOError("Overflowed pending errors in session") :
+          errors.front()->status();
+      while (!errors.empty()) {
+        delete errors.back();
+        errors.pop_back();
+      }
+    }
+    KUDU_RETURN_NOT_OK(s);
+
+    // Close the session.
+    return session->Close();
+  }
+
+private:
+  client::KuduSchema SimpleKuduSchema() {
+    client::KuduSchema s;
+    client::KuduSchemaBuilder b;
+    b.AddColumn("key")->Type(client::KuduColumnSchema::INT32)->NotNull()->PrimaryKey();
+    b.AddColumn("value_string")->Type(client::KuduColumnSchema::STRING)->NotNull();
+
+    // add column by alter schema
+    // b.AddColumn("value_int64")->Type(client::KuduColumnSchema::INT64);
+    CHECK_OK(b.Build(&s));
+    return s;
+  }
+
+public:
+  std::shared_ptr<cppkafka::Consumer> consumer_;
+
+private:
+  cluster::ExternalMiniClusterOptions cluster_opts_;
+
+  const client::KuduSchema schema_;
+  client::sp::shared_ptr<client::KuduTable> table_;
+  std::shared_ptr<rpc::Messenger> client_messenger_;
+
+  CreateTableOptions options_;
+};
+
+// regression testing for CreateTable
+TEST_F(DuplicationITest, CreateTable) {
+  ASSERT_OK(CreateTable());
+}
+
+// Test CreateTable with duplication
+TEST_F(DuplicationITest, CreateTableWithDuplicationAndTestDuplication) {
+  CreateTableOptions options;
+  client::DuplicationInfo dup_info;
+  dup_info.name = "create_table_topic";
+  dup_info.type = client::DuplicationDownstream::KAFKA;
+  options.dup_info = dup_info;
+  options.partition_num = 2;
+  options.replica_refactor = 3;
+  options.table_name = "CreateTableWithDuplication";
+  ASSERT_OK(CreateTable(options, true));
+
+  // @TODO(duyuqi), patch updates, deletes, upsert ...
+  // Write rows
+  int insert_count = 128;
+  int expected_size = insert_count;
+  std::thread t(&DuplicationITest::Consume, this, expected_size);
+  SleepFor(MonoDelta::FromMilliseconds(2000));
+  ASSERT_OK(InsertRows(insert_count));
+  t.join();
+}
+
+TEST_F(DuplicationITest, AlterTableWithDuplicationAndTestDuplication) {
+  std::string kTableName = "AlterTableWithDuplication";
+  CreateTableOptions options;
+  options.partition_num = 2;
+  options.replica_refactor = 3;
+  options.table_name = kTableName;
+  ASSERT_OK(CreateTable(options, false));
+
+  AlterTableOptions alter_options;
+  alter_options.table_name = kTableName;
+  // @TODO(duyuqi)
+  alter_options.info.name = "hello";
+  alter_options.info.type = client::DuplicationDownstream::KAFKA;
+
+  int insert_count = 128;
+  int expected_size = insert_count;
+
+  alter_options.action = Action::kEnableDuplication;
+  ASSERT_OK(AlterTable(alter_options));
+
+  std::thread t(&DuplicationITest::Consume, this, expected_size);
+  SleepFor(MonoDelta::FromMilliseconds(2000));
+  ASSERT_OK(InsertRows(insert_count));
+  t.join();
+  SleepFor(MonoDelta::FromMilliseconds(1000));
+  alter_options.action = Action::kDisableDuplication;
+  ASSERT_OK(AlterTable(alter_options));
+}
+
+TEST_F(DuplicationITest, DuplicatorRecovering) {
+  std::string kTableName = "DuplicatorRecovering";
+  CreateTableOptions options;
+  options.partition_num = 2;
+  options.replica_refactor = 3;
+  options.table_name = kTableName;
+  ASSERT_OK(CreateTable(options, false));
+
+  int insert_count = 128;
+  int expected_size = insert_count;
+  ASSERT_OK(InsertRows(insert_count));
+  
+  std::thread t(&DuplicationITest::Consume, this, expected_size);
+
+  AlterTableOptions alter_options;
+  alter_options.table_name = kTableName;
+  // @TODO(duyuqi)
+  alter_options.info.name = "hello";
+  alter_options.info.type = client::DuplicationDownstream::KAFKA;
+
+  alter_options.action = Action::kEnableDuplication;
+  ASSERT_OK(AlterTable(alter_options));
+  SleepFor(MonoDelta::FromMilliseconds(2000));
+  t.join();
+  SleepFor(MonoDelta::FromMilliseconds(1000));
+
+  alter_options.action = Action::kDisableDuplication;
+  ASSERT_OK(AlterTable(alter_options));
+}
+
+
+} // namespace kudu

--- a/src/kudu/integration-tests/external_mini_cluster-itest-base.cc
+++ b/src/kudu/integration-tests/external_mini_cluster-itest-base.cc
@@ -69,6 +69,9 @@ void ExternalMiniClusterITestBase::StartClusterWithOpts(
                                          cluster_->messenger(),
                                          &ts_map_));
   ASSERT_OK(cluster_->CreateClient(nullptr, &client_));
+  if (opts.enable_duplication) {
+    LOG(INFO) << "test duplication enabled";
+  }
 }
 
 void ExternalMiniClusterITestBase::StopCluster() {

--- a/src/kudu/kserver/kserver.cc
+++ b/src/kudu/kserver/kserver.cc
@@ -169,6 +169,10 @@ Status KuduServer::Init() {
                 .set_trace_metric_prefix("raft")
                 .set_max_threads(server_wide_pool_limit)
                 .Build(&raft_pool_));
+  RETURN_NOT_OK(ThreadPoolBuilder("dupli")
+                .set_trace_metric_prefix("dupli")
+                .set_max_threads(server_wide_pool_limit)
+                .Build(&duplicate_pool_));
 
   num_raft_leaders_ = metric_entity_->FindOrCreateGauge(&METRIC_num_raft_leaders, 0);
 

--- a/src/kudu/kserver/kserver.h
+++ b/src/kudu/kserver/kserver.h
@@ -59,6 +59,7 @@ class KuduServer : public server::ServerBase {
   ThreadPool* tablet_prepare_pool() { return tablet_prepare_pool_.get(); }
   ThreadPool* tablet_apply_pool() { return tablet_apply_pool_.get(); }
   ThreadPool* raft_pool() { return raft_pool_.get(); }
+  ThreadPool* duplicate_pool() { return duplicate_pool_.get(); }
   scoped_refptr<AtomicGauge<int32_t>> num_raft_leaders() { return num_raft_leaders_; }
 
  private:
@@ -73,6 +74,9 @@ class KuduServer : public server::ServerBase {
 
   // Thread pool for Raft-related operations, shared between all tablets.
   std::unique_ptr<ThreadPool> raft_pool_;
+
+  // Thread pool for duplicator operations, shared between all duplicators
+  std::unique_ptr<ThreadPool> duplicate_pool_;
 
   // Gauge counting the number of Raft instances that in leaders mode.
   scoped_refptr<AtomicGauge<int32_t>> num_raft_leaders_;

--- a/src/kudu/master/master.proto
+++ b/src/kudu/master/master.proto
@@ -154,6 +154,9 @@ message SysTabletsEntryPB {
 
   // The delete time of the tablet, in seconds since the epoch.
   optional int64 delete_timestamp = 9;
+
+  // Replica for duplication
+  repeated DuplicationInfo dup_infos = 100;
 }
 
 // The on-disk entry in the sys.catalog table ("metadata" column) for
@@ -211,6 +214,7 @@ message SysTablesEntryPB {
   // table, rather than a system table.
   optional TableTypePB table_type = 14;
 
+
   // Table disk size limit.
   optional int64 table_disk_size_limit = 15;
   // Table row count limit.
@@ -221,6 +225,9 @@ message SysTablesEntryPB {
 
   // The delete time of the table, in seconds since the epoch.
   optional int64 delete_timestamp = 18;
+
+  // Replica for duplication.
+  repeated DuplicationInfo dup_infos = 100;
 }
 
 // The on-disk entry in the sys.catalog table ("metadata" column) to represent
@@ -510,6 +517,23 @@ message GetTabletLocationsResponsePB {
 //  Catalog
 // ============================================================================
 
+enum DuplicationDownstream {
+    INVALID_MAX_SYSTEM = 999;
+    KAFKA = 0;
+}
+
+message DuplicationInfo {
+  // the dup name for alter add or delete
+  required string name = 1;
+  //
+  required DuplicationDownstream type = 2;
+
+  // If not set, server will use the gflag default value
+  optional string uri = 3;
+
+  optional string options = 4;
+}
+
 message CreateTableRequestPB {
   required string name = 1;
   required SchemaPB schema = 2;
@@ -547,8 +571,14 @@ message CreateTableRequestPB {
   // table, rather than a system table.
   optional TableTypePB table_type = 11;
 
+
   // The comment on the table.
   optional string comment = 13;
+
+  // Replica for duplication.
+  // firstly, we support only 1 duplication_infos
+  // TODO(duyuqi), support more than one
+  repeated DuplicationInfo dup_infos = 100;
 }
 
 message CreateTableResponsePB {
@@ -704,6 +734,8 @@ message AlterTableRequestPB {
     ALTER_COLUMN = 4;
     ADD_RANGE_PARTITION = 5;
     DROP_RANGE_PARTITION = 6;
+    ADD_DUPLICATION = 100;
+    DROP_DUPLICATION = 101;
   }
   message AddColumn {
     // The schema to add.
@@ -738,6 +770,12 @@ message AlterTableRequestPB {
     // the range partition to add or drop.
     optional RowOperationsPB range_bounds = 1;
   }
+  message AddDuplication {
+    required DuplicationInfo dup_info = 1;
+  }
+  message DropDuplication {
+    required string name = 1;
+  }
 
   message Step {
     optional StepType type = 1 [ default = UNKNOWN ];
@@ -749,6 +787,8 @@ message AlterTableRequestPB {
     optional AddRangePartition add_range_partition = 5;
     optional DropRangePartition drop_range_partition = 6;
     optional AlterColumn alter_column = 7;
+    optional AddDuplication add_duplication = 100;
+    optional DropDuplication drop_duplication = 101;
   }
 
   required TableIdentifierPB table = 1;

--- a/src/kudu/master/sys_catalog.cc
+++ b/src/kudu/master/sys_catalog.cc
@@ -490,6 +490,7 @@ Status SysCatalogTable::SetupTablet(
   consensus::ServerContext server_ctx{/*quiescing*/nullptr,
                                       master_->num_raft_leaders(),
                                       master_->raft_pool(),
+                                      nullptr,
                                       // Allow sending status-only Raft messages to a master peer
                                       // in FAILED_UNRECOVERABLE state if we allow dynamically
                                       // adding/removing masters.
@@ -580,7 +581,7 @@ Status SysCatalogTable::SyncWrite(const WriteRequestPB& req) {
   WriteResponsePB resp;
   unique_ptr<tablet::OpCompletionCallback> op_callback(
       new LatchOpCompletionCallback<WriteResponsePB>(&latch, &resp));
-  unique_ptr<tablet::WriteOpState> op_state(
+  std::shared_ptr<tablet::WriteOpState> op_state(
       new tablet::WriteOpState(tablet_replica_.get(),
                                &req,
                                nullptr, // No RequestIdPB

--- a/src/kudu/mini-cluster/external_mini_cluster.cc
+++ b/src/kudu/mini-cluster/external_mini_cluster.cc
@@ -128,7 +128,8 @@ ExternalMiniClusterOptions::ExternalMiniClusterOptions()
       enable_encryption(FLAGS_encrypt_data_at_rest),
       logtostderr(true),
       start_process_timeout(MonoDelta::FromSeconds(70)),
-      rpc_negotiation_timeout(MonoDelta::FromSeconds(3))
+      rpc_negotiation_timeout(MonoDelta::FromSeconds(3)),
+      enable_duplication(false)
 #if !defined(NO_CHRONY)
       ,
       num_ntp_servers(1),

--- a/src/kudu/mini-cluster/external_mini_cluster.h
+++ b/src/kudu/mini-cluster/external_mini_cluster.h
@@ -240,6 +240,10 @@ struct ExternalMiniClusterOptions {
   // Default: empty
   LocationInfo location_info;
 
+  // 
+  // Default: false
+  bool enable_duplication;
+
 #if !defined(NO_CHRONY)
   // Number of NTP servers to start as part of the cluster. The NTP servers are
   // used as true time references for the NTP client built into masters and

--- a/src/kudu/rebalance/cluster_status.h
+++ b/src/kudu/rebalance/cluster_status.h
@@ -76,17 +76,18 @@ struct ConsensusState {
                         boost::optional<int64_t> opid_index,
                         boost::optional<std::string> leader_uuid,
                         const std::vector<std::string>& voters,
-                        const std::vector<std::string>& non_voters)
+                        const std::vector<std::string>& non_voters,
+                        const std::vector<std::string>& duplicators = {})
     : type(type),
       term(std::move(term)),
       opid_index(std::move(opid_index)),
       leader_uuid(std::move(leader_uuid)),
       voter_uuids(voters.cbegin(), voters.cend()),
-      non_voter_uuids(non_voters.cbegin(), non_voters.cend()) {
+      non_voter_uuids(non_voters.cbegin(), non_voters.cend()),
+      duplicator_uuids(duplicators.cbegin(), duplicators.cend()) {
    // A consensus state must have a term unless it's one sourced from the master.
    CHECK(type == ConsensusConfigType::MASTER || term);
   }
-
   // Two ConsensusState structs match if they have the same
   // leader_uuid, the same set of peers, and one of the following holds:
   // - at least one of them is of type MASTER
@@ -95,7 +96,8 @@ struct ConsensusState {
     bool same_leader_and_peers =
         leader_uuid == other.leader_uuid &&
         voter_uuids == other.voter_uuids &&
-        non_voter_uuids == other.non_voter_uuids;
+        non_voter_uuids == other.non_voter_uuids && 
+        duplicator_uuids == other.duplicator_uuids;
     if (type == ConsensusConfigType::MASTER ||
         other.type == ConsensusConfigType::MASTER) {
       return same_leader_and_peers;
@@ -109,6 +111,7 @@ struct ConsensusState {
   boost::optional<std::string> leader_uuid;
   std::set<std::string> voter_uuids;
   std::set<std::string> non_voter_uuids;
+  std::set<std::string> duplicator_uuids;
 };
 
 // Represents the health of a server.

--- a/src/kudu/tablet/CMakeLists.txt
+++ b/src/kudu/tablet/CMakeLists.txt
@@ -84,7 +84,8 @@ target_link_libraries(tablet
   gutil
   kudu_fs
   kudu_util
-  consensus)
+  consensus
+  kafka)
 
 add_library(tablet_test_util
   tablet-test-util.cc

--- a/src/kudu/tablet/local_tablet_writer.h
+++ b/src/kudu/tablet/local_tablet_writer.h
@@ -108,7 +108,10 @@ class LocalTabletWriter {
       encoder.Add(op.type, *op.row);
     }
 
-    op_state_.reset(new WriteOpState(NULL, &req_, NULL));
+    consensus::RaftPeerPB local_peer_pb;
+    local_peer_pb.set_member_type(consensus::RaftPeerPB::VOTER);
+    scoped_refptr<TabletReplica> tablet_replica_ptr = new TabletReplica(local_peer_pb);
+    op_state_.reset(new WriteOpState(tablet_replica_ptr.get(), &req_, NULL));
 
     RETURN_NOT_OK(tablet_->DecodeWriteOperations(client_schema_, op_state_.get()));
     RETURN_NOT_OK(tablet_->AcquireRowLocks(op_state_.get()));
@@ -116,7 +119,7 @@ class LocalTabletWriter {
 
     // Create a "fake" OpId and set it in the OpState for anchoring.
     op_state_->mutable_op_id()->CopyFrom(consensus::MaximumOpId());
-    RETURN_NOT_OK(tablet_->ApplyRowOperations(op_state_.get()));
+    RETURN_NOT_OK(tablet_->ApplyRowOperations(op_state_));
 
     result_ = google::protobuf::Arena::CreateMessage<TxResultPB>(
         op_state_->pb_arena());
@@ -156,7 +159,7 @@ class LocalTabletWriter {
 
   TxResultPB* result_ = nullptr;
   tserver::WriteRequestPB req_;
-  std::unique_ptr<WriteOpState> op_state_;
+  std::shared_ptr<WriteOpState> op_state_;
 
   DISALLOW_COPY_AND_ASSIGN(LocalTabletWriter);
 };

--- a/src/kudu/tablet/ops/op_driver.cc
+++ b/src/kudu/tablet/ops/op_driver.cc
@@ -136,7 +136,8 @@ Status OpDriver::Init(unique_ptr<Op> op,
   }
   op_ = std::move(op);
 
-  if (type == consensus::FOLLOWER) {
+
+  if (type == consensus::FOLLOWER || type == consensus::DUPLICA) {
     std::lock_guard<simple_spinlock> lock(opid_lock_);
     op_id_copy_ = op_->state()->op_id();
     DCHECK(op_id_copy_.IsInitialized());
@@ -294,6 +295,8 @@ Status OpDriver::Prepare() {
       RegisterFollowerOpOnResultTracker();
     // ... else we're a client-started op. Make sure we're still the driver of the
     // RPC and give up if we aren't.
+    } else if (op_->type() == consensus::DUPLICA) {
+      RegisterFollowerOpOnResultTracker();
     } else {
       if (state()->are_results_tracked()
           && !state()->result_tracker()->IsCurrentDriver(state()->request_id())) {
@@ -521,11 +524,36 @@ void OpDriver::ApplyTask() {
     SetResponseTimestamp(op_->state(), op_->state()->timestamp());
 
     {
-      TRACE_EVENT1("op", "AsyncAppendCommit", "op", this);
-      CHECK_OK(log_->AsyncAppendCommit(
-          *commit_msg, [](const Status& s) {
-            CrashIfNotOkStatusCB("Enqueued commit operation failed to write to WAL", s);
-          }));
+      // TODO,
+      // if DUPLICA, should persist the last record's OpId which has written to remote ds.
+      // the CommitMsg would not be continuous.
+      // Be Careful, please cr more cautious.
+      bool duplicator_commit = false;
+      if (state()->tablet_replica()->IsDuplicator()) {
+        consensus::OpId last_confirmed_opid = state()->tablet_replica()->last_confirmed_opid();
+        consensus::OpId last_committed_opid = state()->tablet_replica()->last_committed_opid();
+        LOG(INFO) << "duplicator apply last_confirmed_opid(" << last_confirmed_opid.term() <<","
+          << last_confirmed_opid.index() << ")";
+        LOG(INFO) << "duplicator apply last_committed_opid(" << last_committed_opid.term() <<","
+          << last_committed_opid.index() << ")";
+        if (last_confirmed_opid.term() >= last_committed_opid.term()) {
+          duplicator_commit = last_confirmed_opid.index() > last_committed_opid.index();
+          if (duplicator_commit) {
+            commit_msg->mutable_commited_op_id()->CopyFrom(last_confirmed_opid);
+              TRACE_EVENT1("op", "AsyncAppendCommit", "op", this);
+              CHECK_OK(log_->AsyncAppendCommit(*commit_msg, [](const Status& s) {
+                          CrashIfNotOkStatusCB("Enqueued commit operation failed to write to WAL", s);
+                      }));
+            state()->tablet_replica()->set_last_committed_opid(last_confirmed_opid);
+          }
+        }
+      } else {
+        TRACE_EVENT1("op", "AsyncAppendCommit", "op", this);
+        CHECK_OK(log_->AsyncAppendCommit(*commit_msg, [](const Status& s) {
+                    CrashIfNotOkStatusCB("Enqueued commit operation failed to write to WAL", s);
+                }));
+
+      }
     }
 
     // If the client requested COMMIT_WAIT as the external consistency mode

--- a/src/kudu/tablet/ops/write_op.cc
+++ b/src/kudu/tablet/ops/write_op.cc
@@ -142,7 +142,7 @@ Status WriteAuthorizationContext::CheckPrivileges() const {
   return Status::OK();
 }
 
-WriteOp::WriteOp(unique_ptr<WriteOpState> state, DriverType type)
+WriteOp::WriteOp(std::shared_ptr<WriteOpState> state, DriverType type)
   : Op(type, Op::WRITE_OP),
   state_(std::move(state)) {
   start_time_ = MonoTime::Now();
@@ -274,7 +274,8 @@ Status WriteOp::Apply(CommitMsg** commit_msg) {
   }
 
   Tablet* tablet = state()->tablet_replica()->tablet();
-  RETURN_NOT_OK(tablet->ApplyRowOperations(state()));
+  std::shared_ptr<WriteOpState> state_ptr = shared_state();
+  RETURN_NOT_OK(tablet->ApplyRowOperations(state_ptr));
   TRACE("APPLY: Finished.");
 
   UpdatePerRowMetricsAndErrors();

--- a/src/kudu/tablet/ops/write_op.h
+++ b/src/kudu/tablet/ops/write_op.h
@@ -339,10 +339,12 @@ class WriteOpState : public OpState {
 // Executes a write op.
 class WriteOp : public Op {
  public:
-  WriteOp(std::unique_ptr<WriteOpState> state, consensus::DriverType type);
+  WriteOp(std::shared_ptr<WriteOpState> state, consensus::DriverType type);
 
   WriteOpState* state() override { return state_.get(); }
   const WriteOpState* state() const override { return state_.get(); }
+
+  std::shared_ptr<WriteOpState> shared_state() { return state_; }
 
   void NewReplicateMsg(std::unique_ptr<consensus::ReplicateMsg>* replicate_msg) override;
 
@@ -396,7 +398,7 @@ class WriteOp : public Op {
   // this op's start time
   MonoTime start_time_;
 
-  std::unique_ptr<WriteOpState> state_;
+  std::shared_ptr<WriteOpState> state_;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(WriteOp);

--- a/src/kudu/tablet/tablet.h
+++ b/src/kudu/tablet/tablet.h
@@ -189,12 +189,12 @@ class Tablet {
   void StartApplying(ParticipantOpState* op_state);
 
   // Apply all of the row operations associated with this op.
-  Status ApplyRowOperations(WriteOpState* op_state) WARN_UNUSED_RESULT;
+  Status ApplyRowOperations(std::shared_ptr<WriteOpState>& op_state_ptr) WARN_UNUSED_RESULT;
 
   // Apply a single row operation, which must already be prepared.
   // The result is set back into row_op->result.
   Status ApplyRowOperation(const fs::IOContext* io_context,
-                           WriteOpState* op_state,
+                           std::shared_ptr<WriteOpState>& op_state_ptr,
                            RowOp* row_op,
                            ProbeStats* stats) WARN_UNUSED_RESULT;
 

--- a/src/kudu/tablet/tablet_bootstrap-test.cc
+++ b/src/kudu/tablet/tablet_bootstrap-test.cc
@@ -161,6 +161,11 @@ class BootstrapTest : public LogTestBase {
     RETURN_NOT_OK(log_->Close());
 
     scoped_refptr<LogAnchorRegistry> log_anchor_registry(new LogAnchorRegistry());
+    // MockTabletReplica
+    consensus::RaftPeerPB local_peer_pb;
+    local_peer_pb.set_member_type(consensus::RaftPeerPB::VOTER);
+    scoped_refptr<TabletReplica> tablet_replica_ptr = new TabletReplica(local_peer_pb);
+
     // Now attempt to recover the log
     RETURN_NOT_OK(BootstrapTablet(
         meta,
@@ -170,7 +175,7 @@ class BootstrapTest : public LogTestBase {
         /*result_tracker*/nullptr,
         metric_registry_.get(),
         file_cache_.get(),
-        /*tablet_replica*/nullptr,
+        tablet_replica_ptr.get(),
         std::move(log_anchor_registry),
         tablet,
         &log_,

--- a/src/kudu/tablet/tablet_replica-test-base.cc
+++ b/src/kudu/tablet/tablet_replica-test-base.cc
@@ -81,7 +81,7 @@ const MonoDelta kLeadershipTimeout = MonoDelta::FromSeconds(10);
 
 Status TabletReplicaTestBase::ExecuteWrite(TabletReplica* replica, const WriteRequestPB& req) {
   WriteResponsePB resp;
-  unique_ptr<WriteOpState> op_state(new WriteOpState(replica,
+  std::shared_ptr<WriteOpState> op_state(new WriteOpState(replica,
                                                      &req,
                                                      nullptr, // No RequestIdPB
                                                      &resp));

--- a/src/kudu/tablet/tablet_replica-test.cc
+++ b/src/kudu/tablet/tablet_replica-test.cc
@@ -233,7 +233,7 @@ class DelayedApplyOp : public WriteOp {
  public:
   DelayedApplyOp(CountDownLatch* apply_started,
                  CountDownLatch* apply_continue,
-                 unique_ptr<WriteOpState> state)
+                 shared_ptr<WriteOpState> state)
       : WriteOp(std::move(state), consensus::LEADER),
         apply_started_(DCHECK_NOTNULL(apply_started)),
         apply_continue_(DCHECK_NOTNULL(apply_continue)) {
@@ -410,7 +410,7 @@ TEST_F(TabletReplicaTest, TestActiveOpPreventsLogGC) {
   {
     // Long-running mutation.
     ASSERT_OK(GenerateSequentialDeleteRequest(req.get()));
-    unique_ptr<WriteOpState> op_state(new WriteOpState(tablet_replica_.get(),
+    std::shared_ptr<WriteOpState> op_state(new WriteOpState(tablet_replica_.get(),
                                                        req.get(),
                                                        nullptr, // No RequestIdPB
                                                        resp.get()));

--- a/src/kudu/tablet/tablet_replica.cc
+++ b/src/kudu/tablet/tablet_replica.cc
@@ -42,6 +42,7 @@
 #include "kudu/consensus/log_anchor_registry.h"
 #include "kudu/consensus/metadata.pb.h"
 #include "kudu/consensus/opid.pb.h"
+#include "kudu/consensus/opid_util.h"
 #include "kudu/consensus/quorum_util.h"
 #include "kudu/consensus/raft_consensus.h"
 #include "kudu/consensus/time_manager.h"
@@ -183,10 +184,28 @@ TabletReplica::TabletReplica(
                          this->TxnStatusReplicaStateChanged(this->tablet_id(), reason);
                        } : std::move(cb)),
       state_(NOT_INITIALIZED),
-      last_status_("Tablet initializing...") {
+      last_status_("Tablet initializing..."),
+      duplicator_(nullptr),
+      last_committed_opid_(consensus::MinimumOpId()) {
 }
 
+// MockTabletReplica just for Test
+TabletReplica::TabletReplica(const consensus::RaftPeerPB& local_peer_pb) :
+    meta_(nullptr), cmeta_manager_(nullptr),
+    local_peer_pb_(local_peer_pb), log_anchor_registry_(nullptr),
+    apply_pool_(nullptr),
+    reload_txn_status_tablet_pool_(nullptr),
+    txn_coordinator_(nullptr),
+    mark_dirty_clbk_([](const std::string& reason){}),
+    state_(SHUTDOWN),
+    last_status_("Tablet initializing..."), duplicator_(nullptr),
+    last_committed_opid_(consensus::MinimumOpId()) {
+}
 TabletReplica::~TabletReplica() {
+  if (duplicator_ != nullptr) {
+    delete duplicator_;
+    duplicator_ = nullptr;
+  }
   // We are required to call Shutdown() before destroying a TabletReplica.
   CHECK(state_ == SHUTDOWN || state_ == FAILED)
       << "TabletReplica not fully shut down. State: "
@@ -206,6 +225,15 @@ Status TabletReplica::Init(ServerContext server_ctx) {
                                       std::move(server_ctx),
                                       &consensus));
   consensus_ = std::move(consensus);
+  is_duplicator_ = consensus_->IsDuplicator();
+  if (is_duplicator_) {
+    // Init a ThreadPoolToken for the TabletReplica
+    CHECK(server_ctx.duplicate_pool != nullptr);
+    duplicator_ = new duplicator::Duplicator(server_ctx.duplicate_pool, meta_->table_name());
+    duplicator_->Init();
+    VLOG(2) << "Init duplicator Table " << meta_->table_name() << " TableId " <<
+      tablet_id() << " PeerUUID " << consensus_->peer_uuid();
+  }
   set_state(INITIALIZED);
   SetStatusMessage("Initialized. Waiting to start...");
   return Status::OK();
@@ -219,7 +247,8 @@ Status TabletReplica::Start(
     scoped_refptr<ResultTracker> result_tracker,
     scoped_refptr<Log> log,
     ThreadPool* prepare_pool,
-    DnsResolver* resolver) {
+    DnsResolver* resolver,
+    ThreadPool* duplicate_pool) {
   DCHECK(tablet) << "A TabletReplica must be provided with a Tablet";
   DCHECK(log) << "A TabletReplica must be provided with a Log";
 
@@ -275,7 +304,6 @@ Status TabletReplica::Start(
       peer_proxy_factory.reset(new RpcPeerProxyFactory(messenger_, resolver));
       time_manager.reset(new TimeManager(clock_, tablet_->mvcc_manager()->GetCleanTimestamp()));
     }
-
     // We cannot hold 'lock_' while we call RaftConsensus::Start() because it
     // may invoke TabletReplica::StartFollowerOp() during startup,
     // causing a self-deadlock. We take a ref to members protected by 'lock_'
@@ -335,6 +363,10 @@ void TabletReplica::Stop() {
   UnregisterMaintenanceOps();
 
   if (consensus_) consensus_->Stop();
+
+  if (IsDuplicator()) {
+    duplicator_->Shutdown();
+  }
 
   // TODO(KUDU-183): Keep track of the pending tasks and send an "abort" message.
   LOG_SLOW_EXECUTION(WARNING, 1000,
@@ -532,7 +564,7 @@ Status TabletReplica::WaitUntilConsensusRunning(const MonoDelta& timeout) {
 }
 
 Status TabletReplica::SubmitTxnWrite(
-    std::unique_ptr<WriteOpState> op_state,
+    std::shared_ptr<WriteOpState> op_state,
     const std::function<Status(int64_t txn_id, RegisteredTxnCallback cb)>& scheduler) {
   DCHECK(op_state);
   DCHECK(op_state->request()->has_txn_id());
@@ -584,7 +616,7 @@ Status TabletReplica::UnregisterTxnOpDispatcher(int64_t txn_id,
   return unregister_status;
 }
 
-Status TabletReplica::SubmitWrite(unique_ptr<WriteOpState> op_state) {
+Status TabletReplica::SubmitWrite(std::shared_ptr<WriteOpState> op_state) {
   RETURN_NOT_OK(CheckRunning());
 
   op_state->SetResultTracker(result_tracker_);
@@ -792,19 +824,25 @@ Status TabletReplica::StartFollowerOp(const scoped_refptr<ConsensusRound>& round
 
   consensus::ReplicateMsg* replicate_msg = round->replicate_msg();
   DCHECK(replicate_msg->has_timestamp());
+  consensus::DriverType driver_type = consensus::FOLLOWER;
+  if (IsDuplicator()) {
+    LOG(INFO) << LogPrefix() << ", IsDuplicator()";
+    driver_type = consensus::DUPLICA;
+  }
   unique_ptr<Op> op;
   switch (replicate_msg->op_type()) {
     case WRITE_OP:
     {
       DCHECK(replicate_msg->has_write_request()) << "WRITE_OP replica"
           " op must receive a WriteRequestPB";
-      unique_ptr<WriteOpState> op_state(
+      std::shared_ptr<WriteOpState> op_state(
           new WriteOpState(
               this,
               &replicate_msg->write_request(),
               replicate_msg->has_request_id() ? &replicate_msg->request_id() : nullptr));
       op_state->SetResultTracker(result_tracker_);
-      op.reset(new WriteOp(std::move(op_state), consensus::FOLLOWER));
+
+      op.reset(new WriteOp(std::move(op_state), driver_type));
       break;
     }
     case PARTICIPANT_OP:
@@ -817,7 +855,7 @@ Status TabletReplica::StartFollowerOp(const scoped_refptr<ConsensusRound>& round
               tablet_->txn_participant(),
               &replicate_msg->participant_request()));
       op_state->SetResultTracker(result_tracker_);
-      op.reset(new ParticipantOp(std::move(op_state), consensus::FOLLOWER));
+      op.reset(new ParticipantOp(std::move(op_state), driver_type));
       break;
     }
     case ALTER_SCHEMA_OP:
@@ -828,7 +866,7 @@ Status TabletReplica::StartFollowerOp(const scoped_refptr<ConsensusRound>& round
           new AlterSchemaOpState(this, &replicate_msg->alter_schema_request(),
                                  nullptr));
       op.reset(
-          new AlterSchemaOp(std::move(op_state), consensus::FOLLOWER));
+          new AlterSchemaOp(std::move(op_state), driver_type));
       break;
     }
     default:
@@ -840,7 +878,11 @@ Status TabletReplica::StartFollowerOp(const scoped_refptr<ConsensusRound>& round
   state->set_consensus_round(round);
 
   scoped_refptr<OpDriver> driver;
-  RETURN_NOT_OK(NewReplicaOpDriver(std::move(op), &driver));
+  if (IsDuplicator()) {
+    RETURN_NOT_OK(NewDuplicaOpDriver(std::move(op), &driver));
+  } else {
+    RETURN_NOT_OK(NewReplicaOpDriver(std::move(op), &driver));
+  }
 
   // A raw pointer is required to avoid a refcount cycle.
   auto* driver_raw = driver.get();
@@ -905,7 +947,7 @@ Status TabletReplica::NewLeaderOpDriver(unique_ptr<Op> op,
 }
 
 Status TabletReplica::NewReplicaOpDriver(unique_ptr<Op> op,
-                                                  scoped_refptr<OpDriver>* driver) {
+                                         scoped_refptr<OpDriver>* driver) {
   scoped_refptr<OpDriver> op_driver = new OpDriver(
     &op_tracker_,
     consensus_.get(),
@@ -914,6 +956,21 @@ Status TabletReplica::NewReplicaOpDriver(unique_ptr<Op> op,
     apply_pool_,
     &op_order_verifier_);
   RETURN_NOT_OK(op_driver->Init(std::move(op), consensus::FOLLOWER));
+  *driver = std::move(op_driver);
+
+  return Status::OK();
+}
+
+Status TabletReplica::NewDuplicaOpDriver(unique_ptr<Op> op,
+                                         scoped_refptr<OpDriver>* driver) {
+  scoped_refptr<OpDriver> op_driver = new OpDriver(
+    &op_tracker_,
+    consensus_.get(),
+    log_.get(),
+    prepare_pool_token_.get(),
+    apply_pool_,
+    &op_order_verifier_);
+  RETURN_NOT_OK(op_driver->Init(std::move(op), consensus::DUPLICA));
   *driver = std::move(op_driver);
 
   return Status::OK();
@@ -1169,7 +1226,7 @@ void TabletReplica::MakeUnavailable(const Status& error) {
 }
 
 Status TabletReplica::TxnOpDispatcher::Dispatch(
-    std::unique_ptr<WriteOpState> op,
+    std::shared_ptr<WriteOpState> op,
     const std::function<Status(int64_t txn_id, RegisteredTxnCallback cb)>& scheduler) {
   const auto txn_id = op->request()->txn_id();
   std::lock_guard<simple_spinlock> guard(lock_);
@@ -1311,7 +1368,7 @@ Status TabletReplica::TxnOpDispatcher::MarkUnregistered() {
   return Status::OK();
 }
 
-Status TabletReplica::TxnOpDispatcher::EnqueueUnlocked(unique_ptr<WriteOpState> op) {
+Status TabletReplica::TxnOpDispatcher::EnqueueUnlocked(std::shared_ptr<WriteOpState> op) {
   // TODO(aserbin): do we need to track username coming with write operations
   //                to make sure there is no way to slip in write operations for
   //                transactions of other users?
@@ -1329,7 +1386,7 @@ Status TabletReplica::TxnOpDispatcher::EnqueueUnlocked(unique_ptr<WriteOpState> 
 Status TabletReplica::TxnOpDispatcher::RespondWithStatus(
     const Status& status,
     TabletServerErrorPB::Code code,
-    deque<unique_ptr<WriteOpState>> ops) {
+    deque<std::shared_ptr<WriteOpState>> ops) {
   // Invoke the callback for every operation in the queue.
   for (auto& op : ops) {
     auto* cb = op->completion_callback();

--- a/src/kudu/tablet/tablet_replica.h
+++ b/src/kudu/tablet/tablet_replica.h
@@ -31,7 +31,9 @@
 
 #include "kudu/consensus/log.h"
 #include "kudu/consensus/metadata.pb.h"
+#include "kudu/consensus/opid.pb.h"
 #include "kudu/consensus/raft_consensus.h"
+#include "kudu/duplicator/duplicator.h"
 #include "kudu/fs/fs_manager.h"
 #include "kudu/gutil/macros.h"
 #include "kudu/gutil/ref_counted.h"
@@ -53,6 +55,7 @@ class DnsResolver;
 class MaintenanceManager;
 class MaintenanceOp;
 class MonoDelta;
+class Schema;
 class ThreadPool;
 class ThreadPoolToken;
 class TxnOpDispatcherITest;
@@ -90,10 +93,15 @@ class TabletStatusPB;
 class TxnCoordinator;
 class TxnCoordinatorFactory;
 
+
 // Callback to run once the work to register a participant and start a
 // transaction on the participant has completed (whether successful or not).
 typedef std::function<void(const Status& status, tserver::TabletServerErrorPB::Code code)>
     RegisteredTxnCallback;
+
+class WriteOpState;
+struct ProbeStats;
+struct RowOp;
 
 // A replica in a tablet consensus configuration, which coordinates writes to tablets.
 // Each time Write() is called this class appends a new entry to a replicated
@@ -111,6 +119,9 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
                 TxnCoordinatorFactory* txn_coordinator_factory,
                 consensus::MarkDirtyCallback cb);
 
+  // MockTabletReplica just for Test
+  explicit TabletReplica(const consensus::RaftPeerPB& local_peer_pb);
+
   // Initializes RaftConsensus.
   // This must be called before publishing the instance to other threads.
   // If this fails, the TabletReplica instance remains in a NOT_INITIALIZED
@@ -127,7 +138,9 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
                scoped_refptr<rpc::ResultTracker> result_tracker,
                scoped_refptr<log::Log> log,
                ThreadPool* prepare_pool,
-               DnsResolver* resolver);
+               DnsResolver* resolver,
+               ThreadPool* duplicate_pool = nullptr);
+
 
   // Synchronously transition this replica to STOPPED state from any other
   // state. This also stops RaftConsensus. If a Stop() operation is already in
@@ -160,7 +173,7 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
   // replica. The 'scheduler' functor is used to schedule the activities
   // mentioned above.
   Status SubmitTxnWrite(
-      std::unique_ptr<WriteOpState> op_state,
+      std::shared_ptr<WriteOpState> op_state,
       const std::function<Status(int64_t txn_id, RegisteredTxnCallback cb)>& scheduler);
 
   // Unregister TxnWriteOpDispacher for the specified transaction identifier
@@ -175,8 +188,9 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
 
   // Submits a write to a tablet and executes it asynchronously.
   // The caller is expected to build and pass a WriteOpState that points to the
+
   // RPC's WriteRequest, and WriteResponse.
-  Status SubmitWrite(std::unique_ptr<WriteOpState> op_state);
+  Status SubmitWrite(std::shared_ptr<WriteOpState> op_state);
 
   // Submits an op to update transaction participant state, executing it
   // asynchonously.
@@ -309,6 +323,9 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
   Status NewReplicaOpDriver(std::unique_ptr<Op> op,
                             scoped_refptr<OpDriver>* driver);
 
+  Status NewDuplicaOpDriver(std::unique_ptr<Op> op,
+                            scoped_refptr<OpDriver>* driver);
+
   // Tells the tablet's log to garbage collect.
   Status RunLogGC();
 
@@ -361,6 +378,7 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
     return txn_coordinator_.get();
   }
 
+
   // Whether or not to run a new staleness transactions aborting task.
   // If the tablet is part of a transaction status table and is in
   // RUNNING state, register the task by increasing the transaction status
@@ -388,6 +406,35 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
 
   // Submit ParticipantOpPB::BEGIN_TXN operation for the specified transaction.
   void BeginTxnParticipantOp(int64_t txn_id, RegisteredTxnCallback began_txn_cb);
+
+
+  bool IsDuplicator() const {
+    return is_duplicator_;
+  }
+
+  Status Duplicate(const std::shared_ptr<WriteOpState>& op_state_ptr,
+                   RowOp* row_op, ProbeStats* stats, const std::shared_ptr<Schema>& schema) {
+    duplicator_->Duplicate(op_state_ptr, row_op, schema);
+    // TODO(duyuuqi), when bootstrapping it default msr_id is what?
+    // because the mrs is not flush, so the mrs_id is all 0 (first MemRowSet id).
+    // So commit id is 0.
+    // need some stats ?
+    // We need satisfy rows.
+    int32_t mrs_id = (tablet_ == nullptr) ? 0 : tablet_->CurrentMrsIdForTests();
+    row_op->SetInsertSucceeded(mrs_id);
+    stats->mrs_consulted++;
+    return Status::OK();
+  }
+
+  const consensus::OpId last_confirmed_opid() const {
+    return duplicator_->last_confirmed_opid();
+  }
+  void set_last_committed_opid(consensus::OpId last_committed_opid) {
+    last_committed_opid_ = last_committed_opid;
+  }
+  const consensus::OpId last_committed_opid() const {
+    return last_committed_opid_;
+  }
 
  private:
   friend class kudu::AlterTableTest;
@@ -428,7 +475,7 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
     // operation. In the two former cases, returns Status::OK(); in the latter
     // case returns non-OK status correspondingly. The 'scheduler' function is
     // invoked to schedule preliminary tasks, if necessary.
-    Status Dispatch(std::unique_ptr<WriteOpState> op,
+    Status Dispatch(std::shared_ptr<WriteOpState> op,
                     const std::function<Status(int64_t txn_id,
                                                RegisteredTxnCallback cb)>& scheduler);
 
@@ -456,13 +503,13 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
     FRIEND_TEST(kudu::TxnOpDispatcherITest, PreliminaryTasksTimeout);
 
     // Add the specified operation into the queue.
-    Status EnqueueUnlocked(std::unique_ptr<WriteOpState> op);
+    Status EnqueueUnlocked(std::shared_ptr<WriteOpState> op);
 
     // Respond to the given write operations with the specified status.
     static Status RespondWithStatus(
         const Status& status,
         tserver::TabletServerErrorPB::Code code,
-        std::deque<std::unique_ptr<WriteOpState>> ops);
+        std::deque<std::shared_ptr<WriteOpState>> ops);
 
     // Pointer to the parent TabletReplica instance which keeps this
     // TxnOpDispatcher instance in its 'txn_op_dispatchers_' map.
@@ -495,7 +542,7 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
     // Queue to buffer txn write operations while the preliminary work of
     // registering the tablet as a participant in the transaction, etc. are
     // in progress.
-    std::deque<std::unique_ptr<WriteOpState>> ops_queue_;
+    std::deque<std::shared_ptr<WriteOpState>> ops_queue_;
   };
 
   ~TabletReplica();
@@ -572,6 +619,7 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
   std::shared_ptr<Tablet> tablet_;
   std::shared_ptr<rpc::Messenger> messenger_;
   std::shared_ptr<consensus::RaftConsensus> consensus_;
+  bool is_duplicator_ = false;
 
   // Lock protecting state_, last_status_, as well as pointers to collaborating
   // classes such as tablet_, consensus_, and maintenance_ops_.
@@ -591,6 +639,10 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
 
   // Token for serial task submission to the server-wide op prepare pool.
   std::unique_ptr<ThreadPoolToken> prepare_pool_token_;
+
+  // duplicator will replicate wals to third store system
+  duplicator::Duplicator* duplicator_;
+  consensus::OpId last_committed_opid_;
 
   clock::Clock* clock_;
 

--- a/src/kudu/tools/ksck.cc
+++ b/src/kudu/tools/ksck.cc
@@ -146,6 +146,8 @@ void BuildConsensusStateForConfigMember(const consensus::ConsensusStatePB& cstat
   for (const auto& pb : peers) {
     if (pb.member_type() == consensus::RaftPeerPB::NON_VOTER) {
       InsertOrDie(&ksck_cstate->non_voter_uuids, pb.permanent_uuid());
+    } else if (pb.member_type() == consensus::RaftPeerPB::DUPLICATOR) {
+      InsertOrDie(&ksck_cstate->duplicator_uuids, pb.permanent_uuid());
     } else {
       InsertOrDie(&ksck_cstate->voter_uuids, pb.permanent_uuid());
     }
@@ -886,9 +888,12 @@ HealthCheckResult Ksck::VerifyTablet(const shared_ptr<KsckTablet>& tablet,
   }
   vector<string> voter_uuids_from_master;
   vector<string> non_voter_uuids_from_master;
+  vector<string> duplicator_uuids_from_master;
   for (const auto& replica : tablet->replicas()) {
     if (replica->is_voter()) {
       voter_uuids_from_master.push_back(replica->ts_uuid());
+    } else if (replica->is_duplicator()) {
+      duplicator_uuids_from_master.push_back(replica->ts_uuid());
     } else {
       non_voter_uuids_from_master.push_back(replica->ts_uuid());
     }
@@ -898,10 +903,13 @@ HealthCheckResult Ksck::VerifyTablet(const shared_ptr<KsckTablet>& tablet,
                                boost::none,
                                leader_uuid,
                                voter_uuids_from_master,
-                               non_voter_uuids_from_master);
+                               non_voter_uuids_from_master,
+                               duplicator_uuids_from_master);
 
   int leaders_count = 0;
+  int duplicators_count = 0;
   int running_voters_count = 0;
+  int running_duplicators_count = 0;
   int copying_replicas_count = 0;
   int conflicting_states = 0;
   int num_voters = 0;
@@ -942,8 +950,13 @@ HealthCheckResult Ksck::VerifyTablet(const shared_ptr<KsckTablet>& tablet,
     if (replica->is_leader()) {
       leaders_count++;
     }
+    if (replica->is_duplicator()) {
+      duplicators_count++;
+    }
     if (repl_info->state == tablet::RUNNING && replica->is_voter()) {
       running_voters_count++;
+    } else if (repl_info->state == tablet::RUNNING && replica->is_duplicator()) {
+      running_duplicators_count++;
     } else if (repl_info->status_pb &&
                repl_info->status_pb->tablet_data_state() == tablet::TABLET_DATA_COPYING) {
       copying_replicas_count++;

--- a/src/kudu/tools/ksck.h
+++ b/src/kudu/tools/ksck.h
@@ -78,6 +78,13 @@ class KsckTabletReplica {
     return is_voter_;
   }
 
+  // TODO, In fact, !is_voter stable is duplicator, but
+  // not strict correct. When recovering a replica, the replica is non voter, 
+  // and when recovering finished, it promote to voter.
+  bool is_duplicator() {
+    return !is_voter_;
+  }
+
  private:
   const std::string ts_uuid_;
   const bool is_leader_;

--- a/src/kudu/tools/tool_action_perf.cc
+++ b/src/kudu/tools/tool_action_perf.cc
@@ -198,6 +198,7 @@
 #include "kudu/consensus/consensus_meta_manager.h"
 #include "kudu/consensus/log.h"
 #include "kudu/consensus/log_anchor_registry.h"
+#include "kudu/consensus/metadata.pb.h"
 #include "kudu/consensus/raft_consensus.h"
 #include "kudu/fs/fs_manager.h"
 #include "kudu/gutil/map-util.h"
@@ -970,6 +971,12 @@ Status TabletScan(const RunnerContext& context) {
   std::shared_ptr<Tablet> tablet;
   scoped_refptr<Log> log;
   ConsensusBootstrapInfo cbi;
+
+  // MockTabletReplica
+  consensus::RaftPeerPB local_peer_pb;
+  local_peer_pb.set_member_type(consensus::RaftPeerPB::VOTER);
+  scoped_refptr<tablet::TabletReplica> tablet_replica_ptr =
+    new tablet::TabletReplica(local_peer_pb);
   RETURN_NOT_OK(tablet::BootstrapTablet(std::move(tmeta),
                                         cmeta->CommittedConfig(),
                                         &clock,
@@ -977,7 +984,7 @@ Status TabletScan(const RunnerContext& context) {
                                         /*result_tracker=*/ nullptr,
                                         /*metric_registry=*/ nullptr,
                                         /*file_cache=*/ nullptr,
-                                        /*tablet_replica=*/ nullptr,
+                                        tablet_replica_ptr.get(),
                                         std::move(registry),
                                         &tablet,
                                         &log,

--- a/src/kudu/transactions/txn_status_tablet.cc
+++ b/src/kudu/transactions/txn_status_tablet.cc
@@ -367,11 +367,10 @@ Status TxnStatusTablet::SyncWrite(const WriteRequestPB& req, TabletServerErrorPB
   WriteResponsePB resp;
   unique_ptr<OpCompletionCallback> op_cb(
       new LatchOpCompletionCallback<WriteResponsePB>(&latch, &resp));
-  unique_ptr<WriteOpState> op_state(
-      new WriteOpState(tablet_replica_,
+  std::shared_ptr<WriteOpState> op_state = std::make_shared<WriteOpState>(tablet_replica_,
                        &req,
                        nullptr, // RequestIdPB
-                       &resp));
+                       &resp);
   op_state->set_completion_callback(std::move(op_cb));
   RETURN_NOT_OK(tablet_replica_->SubmitWrite(std::move(op_state)));
   latch.Wait();

--- a/src/kudu/tserver/tablet_copy_source_session-test.cc
+++ b/src/kudu/tserver/tablet_copy_source_session-test.cc
@@ -213,7 +213,7 @@ class TabletCopyTest : public KuduTabletTest {
       WriteResponsePB resp;
       CountDownLatch latch(1);
 
-      unique_ptr<tablet::WriteOpState> state(
+      std::shared_ptr<tablet::WriteOpState> state(
           new tablet::WriteOpState(tablet_replica_.get(),
                                    &req,
                                    nullptr, // No RequestIdPB

--- a/src/kudu/tserver/tablet_service.cc
+++ b/src/kudu/tserver/tablet_service.cc
@@ -1644,12 +1644,12 @@ void TabletServiceImpl::Write(const WriteRequestPB* req,
     }
   }
 
-  unique_ptr<WriteOpState> op_state(new WriteOpState(
+  std::shared_ptr<WriteOpState> op_state = std::make_shared<WriteOpState>(
       replica.get(),
       req,
       context->AreResultsTracked() ? context->request_id() : nullptr,
       resp,
-      std::move(authz_context)));
+      std::move(authz_context));
 
   // If the client sent us a timestamp, decode it and update the clock so that all future
   // timestamps are greater than the passed timestamp.

--- a/src/kudu/tserver/ts_tablet_manager.cc
+++ b/src/kudu/tserver/ts_tablet_manager.cc
@@ -1007,7 +1007,8 @@ Status TSTabletManager::CreateAndRegisterTabletReplica(
                         }));
   Status s = replica->Init({ server_->mutable_quiescing(),
                              server_->num_raft_leaders(),
-                             server_->raft_pool() });
+                             server_->raft_pool(),
+                             server_->duplicate_pool() });
   if (PREDICT_FALSE(!s.ok())) {
     replica->SetError(s);
     replica->Shutdown();
@@ -1393,7 +1394,8 @@ void TSTabletManager::OpenTablet(const scoped_refptr<tablet::TabletReplica>& rep
                        server_->result_tracker(),
                        log,
                        server_->tablet_prepare_pool(),
-                       server_->dns_resolver());
+                       server_->dns_resolver(),
+                       server_->duplicate_pool());
     if (!s.ok()) {
       LOG(ERROR) << LogPrefix(tablet_id) << "Tablet failed to start: "
                  << s.ToString();

--- a/thirdparty/build-definitions.sh
+++ b/thirdparty/build-definitions.sh
@@ -1142,3 +1142,26 @@ build_jwt_cpp() {
   make -j$PARALLEL install
   popd
 }
+
+build_librdkafka() {
+    local RDKAFKA_ROOT=$TP_SOURCE_DIR/$LIBRDKAFKA_NAME
+    pushd $RDKAFKA_ROOT
+    ./configure --prefix=$PREFIX_DEPS
+    make -j$PARALLEL
+    make install
+    popd
+}
+build_cppkafka() {
+    local CPPKAFKA_ROOT=$TP_SOURCE_DIR/$CPPKAFKA_NAME
+    mkdir -p $CPPKAFKA_ROOT/build
+
+    pushd $CPPKAFKA_ROOT/build
+    cmake .. -DRDKAFKA_ROOT_DIR=$PREFIX_DEPS -DCMAKE_INSTALL_PREFIX=$PREFIX_DEPS
+    make -j$PARALLEL
+    make install
+
+    cmake .. -DRDKAFKA_ROOT_DIR=$PREFIX_DEPS -DCMAKE_INSTALL_PREFIX=$PREFIX_DEPS -DCPPKAFKA_BUILD_SHARED=0
+    make -j$PARALLEL
+    make install
+    popd
+}

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -108,6 +108,8 @@ else
       "oatpp")        F_OATPP=1 ;;
       "oatpp-swagger") F_OATPP_SWAGGER=1 ;;
       "jwt-cpp")      F_JWT_CPP=1;;
+      "rdkafka")      F_KAFKA=1 ;;
+      "cppkafka")     F_KAFKA=1 ;;
       *)              echo "Unknown module: $arg"; exit 1 ;;
     esac
   done
@@ -424,6 +426,11 @@ fi
 
 if [ -n "$F_UNINSTRUMENTED" -o -n "$F_JWT_CPP" ]; then
   build_jwt_cpp
+fi
+
+if [ -n "$F_UNINSTRUMENTED" -o -n "$F_KAFKA" ]; then
+  build_librdkafka
+  build_cppkafka
 fi
 
 restore_env

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -482,5 +482,16 @@ fetch_and_patch \
   $JWT_CPP_SOURCE \
   $JWT_CPP_PATCHLEVEL
 
+if [ ! -d $LIBRDKAFKA_NAME ]; then
+    rm -rf $LIBRDKAFKA_NAME.tar.gz
+    wget $LIBRDKAFKA_URL -O $LIBRDKAFKA_NAME.tar.gz
+    tar xzvf $LIBRDKAFKA_NAME.tar.gz
+fi
+if [ ! -d $CPPKAFKA_NAME ]; then
+    rm -rf $CPPKAFKA_NAME.tar.gz
+    wget $CPPKAFKA_URL -O $CPPKAFKA_NAME.tar.gz
+    tar xzvf $CPPKAFKA_NAME.tar.gz
+fi
+
 echo "---------------"
 echo "Thirdparty dependencies downloaded successfully"

--- a/thirdparty/kafka-simple-control.sh
+++ b/thirdparty/kafka-simple-control.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# a simple control for kafka standalone. for kudu duplicator itest
+
+set -e
+
+function usage() {
+    echo "usage: =(install|start|stop|uninstall)"
+}
+
+if [[ -z $1 ]]; then
+    echo "you should input an action"
+    usage
+    exit 1
+fi
+
+action=$1
+
+kafka_package_name=kafka_2.13-3.1.0
+kafka_package=$kafka_package_name.tgz
+
+brokers_list=localhost:9092
+topic_name=kudu_profile_record_stream
+kafka_target=itest-kafka-1279
+
+function download_kafka() {
+    pushd /tmp
+    if [ x"$kafka_package" != x ] && [ -f $kafka_package ]; then
+        echo "/tmp/kafka has exist, skip download"
+    else
+        # @TODO(duyuqi), a temp skyline,  fix it.
+        wget -q http://10.120.234.157:8088/$kafka_package -O $kafka_package
+        tar xzf $kafka_package
+        mv $kafka_package_name $kafka_target
+    fi
+    popd
+}
+
+function start_kafka() {
+    download_kafka
+    pushd /tmp/$kafka_target
+    # Start the ZooKeeper service
+    # Note: Soon, ZooKeeper will no longer be required by Apache Kafka.
+    bin/zookeeper-server-start.sh config/zookeeper.properties \
+        &> /tmp/zookeeper.out </dev/null &
+
+    # Start the Kafka broker service
+    bin/kafka-server-start.sh config/server.properties \
+        &> /tmp/kafka-server.out </dev/null &
+
+    sleep 5 
+    popd
+}
+
+function create_topic() {
+    pushd /tmp/$kafka_target
+    bin/kafka-topics.sh --create --topic $topic_name --bootstrap-server $brokers_list
+    sleep 1
+    bin/kafka-topics.sh --describe --topic $topic_name --bootstrap-server $brokers_list
+    echo "create_topic success"
+    popd
+}
+
+function test_write_and_read() {
+    # Test kafka service ok? mannual confirm service
+
+    pushd /tmp/$kafka_target
+    # producer
+    bin/kafka-console-producer.sh --topic $topic_name --bootstrap-server $brokers_list
+
+    # consumer
+    bin/kafka-console-consumer.sh --topic $topic_name --from-beginning --bootstrap-server $brokers_list
+    popd
+}
+
+function stop_kafka() {
+    ## TODO(duyuqi) should fix it.
+    # stop server, 
+    ps auxwf | grep kafka.Kafka | grep -v grep \
+        | awk '{print $2}' | xargs -i kill -9 {}
+    ps auxwf | grep org.apache.zookeeper.server.quorum.QuorumPeerMain \
+        | grep -v grep | awk '{print $2}' | xargs -i kill -9 {}
+    
+    rm -rf /tmp/$kafka_target /tmp/zookeeper /tmp/kafka-logs
+}
+
+function uninstall_kafka() {
+    stop_kafka
+    clean_env
+}
+
+function clean_env() {
+    rm -rf /tmp/$kafka_target /tmp/zookeeper /tmp/kafka-logs /tmp/$kafka_package
+}
+
+case $action in 
+    "install")
+        download_kafka
+        exit 0
+        ;;
+    "start")
+        start_kafka
+        create_topic
+        exit 0
+        ;;
+    "stop")
+        stop_kafka
+        clean_env
+        exit 0
+        ;;
+    "uninstall")
+        uninstall_kafka
+        exit 0
+        ;;
+esac

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -271,3 +271,13 @@ JWT_CPP_VERSION=3bd600762a70faccc7ec1c2dacb999cba6c6ef5e
 JWT_CPP=jwt-cpp
 JWT_CPP_NAME=$JWT_CPP-$JWT_CPP_VERSION
 JWT_CPP_SOURCE=$TP_SOURCE_DIR/$JWT_CPP_NAME
+
+# librdkafka
+LIBRDKAFKA_VERSION=1.8.2-RC4
+LIBRDKAFKA_NAME=librdkafka-$LIBRDKAFKA_VERSION
+LIBRDKAFKA_URL=https://github.com/edenhill/librdkafka/archive/refs/tags/v$LIBRDKAFKA_VERSION.tar.gz
+
+# cppkafka
+CPPKAFKA_VERSION=0.3.1
+CPPKAFKA_NAME=cppkafka-$CPPKAFKA_VERSION
+CPPKAFKA_URL=https://github.com/mfontanini/cppkafka/archive/refs/tags/v$CPPKAFKA_VERSION.tar.gz


### PR DESCRIPTION
add a new MemberType: Duplicator.
add thirdparty for librdkafka and cppkafka.
add thread pool for duplicator, add kafka client for duplication.
support create table with duplictor
support alter table for enable/disable duplication
fix unit tests and add unit tests
support kerberos for kafka client

Conflicts:
	CMakeLists.txt
	java/kudu-client/src/main/java/org/apache/kudu/client/CreateTableOptions.java
	src/kudu/consensus/consensus.proto
	src/kudu/integration-tests/fuzz-itest.cc
	src/kudu/master/catalog_manager.cc
	src/kudu/master/master.proto
	src/kudu/tablet/ops/op_driver.cc
	src/kudu/tablet/tablet_replica.cc
	src/kudu/tablet/tablet_replica.h
	thirdparty/build-thirdparty.sh
	thirdparty/vars.sh